### PR TITLE
Tests for processing types

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -190,16 +190,16 @@ func (p *Package) processObject(o types.Object) {
 
 	if s, ok := n.Underlying().(*types.Struct); ok {
 
-		st := p.processStruct(&Struct{Name: o.Name()}, s)
+		st := processStruct(&Struct{Name: o.Name()}, s)
 		p.Structs = append(p.Structs, st)
 		return
 	}
 
 	name := fmt.Sprintf("%s.%s", n.Obj().Pkg().Path(), n.Obj().Name())
-	p.Aliases[name] = p.processType(n.Underlying())
+	p.Aliases[name] = processType(n.Underlying())
 }
 
-func (p *Package) processType(typ types.Type) (t Type) {
+func processType(typ types.Type) (t Type) {
 	switch u := typ.(type) {
 	case *types.Named:
 		t = NewNamed(
@@ -209,16 +209,16 @@ func (p *Package) processType(typ types.Type) (t Type) {
 	case *types.Basic:
 		t = NewBasic(u.Name())
 	case *types.Slice:
-		t = p.processType(u.Elem())
+		t = processType(u.Elem())
 		t.SetRepeated(true)
 	case *types.Array:
-		t = p.processType(u.Elem())
+		t = processType(u.Elem())
 		t.SetRepeated(true)
 	case *types.Pointer:
-		t = p.processType(u.Elem())
+		t = processType(u.Elem())
 	case *types.Map:
-		key := p.processType(u.Key())
-		val := p.processType(u.Elem())
+		key := processType(u.Key())
+		val := processType(u.Elem())
 		t = NewMap(key, val)
 	default:
 		fmt.Printf("ignoring type %s\n", typ.String())
@@ -233,7 +233,7 @@ func (p *Package) processEnumValue(name string, named *types.Named) {
 	p.values[typ] = append(p.values[typ], name)
 }
 
-func (p *Package) processStruct(s *Struct, elem *types.Struct) *Struct {
+func processStruct(s *Struct, elem *types.Struct) *Struct {
 	for i := 0; i < elem.NumFields(); i++ {
 		v := elem.Field(i)
 		tags := findProtoTags(elem.Tag(i))
@@ -244,14 +244,14 @@ func (p *Package) processStruct(s *Struct, elem *types.Struct) *Struct {
 		if v.Anonymous() {
 			embedded := findStruct(v.Type())
 			if embedded != nil {
-				s = p.processStruct(s, embedded)
+				s = processStruct(s, embedded)
 			}
 			continue
 		}
 
 		f := &Field{
 			Name: v.Name(),
-			Type: p.processType(v.Type()),
+			Type: processType(v.Type()),
 		}
 		if f.Type == nil {
 			continue

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -1,6 +1,8 @@
 package scanner
 
 import (
+	"go/token"
+	"go/types"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,4 +39,83 @@ func TestParseSourceFiles(t *testing.T) {
 	require.Nil(t, err)
 
 	require.Equal(t, "foo", pkg.Name())
+}
+
+func TestProcessType(t *testing.T) {
+	cases := []struct {
+		name     string
+		typ      types.Type
+		expected Type
+	}{
+		{
+			"named type",
+			newNamed("/foo/bar", "Bar", nil),
+			NewNamed("/foo/bar", "Bar"),
+		},
+		{
+			"basic type",
+			types.Typ[types.Int],
+			NewBasic("int"),
+		},
+		{
+			"basic array",
+			types.NewArray(types.Typ[types.Int], 8),
+			repeated(NewBasic("int")),
+		},
+		{
+			"basic slice",
+			types.NewSlice(types.Typ[types.Int]),
+			repeated(NewBasic("int")),
+		},
+		{
+			"basic behind a pointer",
+			types.NewPointer(types.Typ[types.Int]),
+			NewBasic("int"),
+		},
+		{
+			"named behind a pointer",
+			types.NewPointer(newNamed("/foo/bar", "Bar", nil)),
+			NewNamed("/foo/bar", "Bar"),
+		},
+		{
+			"map of basic and named",
+			types.NewMap(
+				types.Typ[types.Int],
+				newNamed("/foo/bar", "Bar", nil),
+			),
+			NewMap(
+				NewBasic("int"),
+				NewNamed("/foo/bar", "Bar"),
+			),
+		},
+		{
+			"struct",
+			types.NewStruct(nil, nil),
+			nil,
+		},
+		{
+			"interface",
+			types.NewInterface(nil, nil),
+			nil,
+		},
+	}
+
+	for _, c := range cases {
+		require.Equal(t, c.expected, processType(c.typ), c.name)
+	}
+}
+
+func repeated(t Type) Type {
+	t.SetRepeated(true)
+	return t
+}
+
+func newNamed(path, name string, underlying types.Type) types.Type {
+	obj := types.NewTypeName(
+		token.NoPos,
+		types.NewPackage(path, "mock"),
+		name,
+		underlying,
+	)
+	return types.NewNamed(obj, underlying, nil)
 }


### PR DESCRIPTION
Use this PR if you want to comment on previous stuff as I did not do a PR with the initial implementation of the scanner (also, maybe Scanner is not a very good name)

This PR includes the tests for `processType` and makes some `Package` methods functions instead because they do not need any access to the `Package` itself and it makes it easier for testing.