### PR TITLE
Implement protobuf transformer

### DIFF
--- a/fixtures/bar.go
+++ b/fixtures/bar.go
@@ -1,5 +1,6 @@
-// +build ignore
 package foo
+
+import "github.com/src-d/proteus/fixtures/subpkg"
 
 type Bar struct {
 	Bar uint64
@@ -7,6 +8,11 @@ type Bar struct {
 }
 
 type Baz byte
+
+type Saz struct {
+	Point subpkg.Point
+	Foo   float64
+}
 
 const (
 	ABaz Baz = iota

--- a/fixtures/foo.go
+++ b/fixtures/foo.go
@@ -1,4 +1,3 @@
-// +build ignore
 package foo
 
 import (

--- a/fixtures/subpkg/foo.go
+++ b/fixtures/subpkg/foo.go
@@ -1,4 +1,3 @@
-// +build ignore
 package subpkg
 
 type Point struct {

--- a/protobuf/mapping.go
+++ b/protobuf/mapping.go
@@ -1,0 +1,49 @@
+package protobuf
+
+// ProtobufType represents a protobuf type. It can optionally have a
+// package and it may require an import to work.
+type ProtobufType struct {
+	Package string
+	Basic   bool
+	Name    string
+	Import  string
+}
+
+// Type returns the type representation of the protobuf type.
+func (t *ProtobufType) Type() Type {
+	if t.Basic {
+		return NewBasic(t.Name)
+	}
+	return NewNamed(t.Package, t.Name)
+}
+
+// TypeMappings is a mapping between Go types and protobuf types.
+// The names of the Go types can have packages. For example: "time.Time" is a
+// valid name. "foo.bar/baz.Qux" is a valid type name as well.
+type TypeMappings map[string]*ProtobufType
+
+var defaultMappings = TypeMappings{
+	"float64": &ProtobufType{Name: "double", Basic: true},
+	"float32": &ProtobufType{Name: "float", Basic: true},
+	"int32":   &ProtobufType{Name: "int32", Basic: true},
+	"int64":   &ProtobufType{Name: "int64", Basic: true},
+	"uint32":  &ProtobufType{Name: "uint32", Basic: true},
+	"uint64":  &ProtobufType{Name: "uint64", Basic: true},
+	"bool":    &ProtobufType{Name: "bool", Basic: true},
+	"string":  &ProtobufType{Name: "string", Basic: true},
+	"uint8":   &ProtobufType{Name: "uint32", Basic: true},
+	"int8":    &ProtobufType{Name: "int32", Basic: true},
+	"byte":    &ProtobufType{Name: "uint32", Basic: true},
+	"uint16":  &ProtobufType{Name: "uint32", Basic: true},
+	"int16":   &ProtobufType{Name: "int32", Basic: true},
+	"int":     &ProtobufType{Name: "int32", Basic: true},
+	"uint":    &ProtobufType{Name: "uint32", Basic: true},
+	"uintptr": &ProtobufType{Name: "uint64", Basic: true},
+	"rune":    &ProtobufType{Name: "int32", Basic: true},
+	"time.Time": &ProtobufType{
+		Name:    "Timestamp",
+		Package: "google.protobuf",
+		Import:  "google/protobuf/timestamp.proto",
+	},
+	"time.Duration": &ProtobufType{Name: "int64"},
+}

--- a/protobuf/protobuf.go
+++ b/protobuf/protobuf.go
@@ -1,0 +1,150 @@
+package protobuf
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// Package represents an unique .proto file with its own package definition.
+type Package struct {
+	Name     string
+	Path     string
+	Imports  []string
+	Options  Options
+	Messages []*Message
+	Enums    []*Enum
+}
+
+// Import tries to import the given protobuf type to the current package.
+// If the type requires no import at all, nothing will be done.
+func (p *Package) Import(typ *ProtobufType) {
+	if typ.Import != "" && !p.isImported(typ.Import) {
+		p.Imports = append(p.Imports, typ.Import)
+	}
+}
+
+// ImportFromPath adds a new import from a Go path.
+func (p *Package) ImportFromPath(path string) {
+	file := filepath.Join(path, "generated.proto")
+	if path != p.Path && !p.isImported(file) {
+		p.Imports = append(p.Imports, filepath.Join(path, "generated.proto"))
+	}
+}
+
+func (p *Package) isImported(file string) bool {
+	for _, i := range p.Imports {
+		if i == file {
+			return true
+		}
+	}
+	return false
+}
+
+// Message is the representation of a Protobuf message.
+type Message struct {
+	Name     string
+	Reserved []int
+	Options  Options
+	Fields   []*Field
+}
+
+// Reserve reserves a position in the message.
+func (m *Message) Reserve(pos int) {
+	m.Reserved = append(m.Reserved, pos)
+}
+
+// Fields is the representation of a protobuf message field.
+type Field struct {
+	Name     string
+	Pos      int
+	Repeated bool
+	Nullable bool
+	Type     Type
+	Options  Options
+}
+
+// Options are the set of options given to a field, message or enum value.
+type Options map[string]OptionValue
+
+// OptionValue is the common interface for the value of an option, which can be
+// a literal value (a number, true, etc) or a string value ("foo").
+type OptionValue interface {
+	fmt.Stringer
+	isOptionValue()
+}
+
+// LiteralValue is a literal option value like true, false or a number.
+type LiteralValue string
+
+func (LiteralValue) isOptionValue() {}
+func (v LiteralValue) String() string {
+	return string(v)
+}
+
+// StringValue is a string option value.
+type StringValue string
+
+func (StringValue) isOptionValue() {}
+func (v StringValue) String() string {
+	return fmt.Sprintf("%q", v)
+}
+
+// Type is the common interface of all possible types, which are named types,
+// maps and basic types.
+type Type interface {
+	isType()
+}
+
+// Named is a type which has a name and is defined somewhere else, maybe even
+// in another package.
+type Named struct {
+	Package string
+	Name    string
+}
+
+func NewNamed(pkg, name string) *Named {
+	return &Named{pkg, name}
+}
+
+// Basic is one of the basic types of protobuf.
+type Basic string
+
+func NewBasic(name string) *Basic {
+	b := Basic(name)
+	return &b
+}
+
+// Map is a key-value map type.
+type Map struct {
+	Key   Type
+	Value Type
+}
+
+func NewMap(k, v Type) *Map {
+	return &Map{k, v}
+}
+
+func (*Named) isType() {}
+func (*Basic) isType() {}
+func (*Map) isType()   {}
+
+// Enum is the representation of a protobuf enumeration.
+type Enum struct {
+	Name    string
+	Options Options
+	Values  EnumValues
+}
+
+// EnumValues is a collction of enumeration values.
+type EnumValues []*EnumValue
+
+func (v *EnumValues) Add(name string, val uint, options Options) {
+	*v = EnumValues(append(*v, &EnumValue{name, val, options}))
+}
+
+// EnumValue is a single value in an enumeration.
+type EnumValue struct {
+	Name    string
+	Value   uint
+	Options Options
+}

--- a/protobuf/protobuf.go
+++ b/protobuf/protobuf.go
@@ -43,14 +43,25 @@ func (p *Package) isImported(file string) bool {
 // Message is the representation of a Protobuf message.
 type Message struct {
 	Name     string
-	Reserved []int
+	Reserved []uint
 	Options  Options
 	Fields   []*Field
 }
 
 // Reserve reserves a position in the message.
-func (m *Message) Reserve(pos int) {
-	m.Reserved = append(m.Reserved, pos)
+func (m *Message) Reserve(pos uint) {
+	if !m.isReserved(pos) {
+		m.Reserved = append(m.Reserved, pos)
+	}
+}
+
+func (m *Message) isReserved(pos uint) bool {
+	for _, r := range m.Reserved {
+		if r == pos {
+			return true
+		}
+	}
+	return false
 }
 
 // Fields is the representation of a protobuf message field.

--- a/protobuf/transform.go
+++ b/protobuf/transform.go
@@ -73,7 +73,7 @@ func (t *Transformer) transformStruct(pkg *Package, s *scanner.Struct) *Message 
 	for i, f := range s.Fields {
 		field := t.transformField(pkg, f, i+1)
 		if field == nil {
-			msg.Reserve(i + 1)
+			msg.Reserve(uint(i) + 1)
 			report.Warn("field %q of struct %q has an invalid type, ignoring field but reserving its position", f.Name, s.Name)
 			continue
 		}
@@ -127,6 +127,8 @@ func (t *Transformer) transformType(pkg *Package, typ scanner.Type) Type {
 			pkg.Import(protoType)
 			return protoType.Type()
 		}
+
+		report.Warn("basic type %q is not defined in the mappings, ignoring", ty.Name)
 	case *scanner.Map:
 		return NewMap(
 			t.transformType(pkg, ty.Key),
@@ -134,8 +136,6 @@ func (t *Transformer) transformType(pkg *Package, typ scanner.Type) Type {
 		)
 	}
 
-	// TODO: only way to reach this is with a basic type that is not defined in the
-	// mappings. Probably should panic?
 	return nil
 }
 

--- a/protobuf/transform.go
+++ b/protobuf/transform.go
@@ -1,0 +1,189 @@
+package protobuf
+
+import (
+	"bytes"
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/src-d/proteus/report"
+	"github.com/src-d/proteus/scanner"
+)
+
+// Transformer is in charge of converting scanned Go entities to protobuf
+// entities as well as mapping between Go and Protobuf types.
+// Take into account that custom mappings are used first to check for the
+// corresponding type mapping, and then the default mappings to give the user
+// ability to override any kind of type.
+type Transformer struct {
+	mappings TypeMappings
+}
+
+func NewTransformer() *Transformer {
+	return &Transformer{
+		mappings: make(TypeMappings),
+	}
+}
+
+// SetMappings will set the custom mappings of the transformer. If nil is
+// provided, the change will be ignored.
+func (t *Transformer) SetMappings(m TypeMappings) {
+	if m == nil {
+		return
+	}
+	t.mappings = m
+}
+
+// Transform converts a scanned package to a protobuf package.
+func (t *Transformer) Transform(p *scanner.Package) *Package {
+	pkg := &Package{
+		Name: toProtobufPkg(p.Path),
+		Path: p.Path,
+	}
+
+	for _, s := range p.Structs {
+		msg := t.transformStruct(pkg, s)
+		pkg.Messages = append(pkg.Messages, msg)
+	}
+
+	for _, e := range p.Enums {
+		enum := t.transformEnum(e)
+		pkg.Enums = append(pkg.Enums, enum)
+	}
+
+	return pkg
+}
+
+func (t *Transformer) transformEnum(e *scanner.Enum) *Enum {
+	enum := &Enum{Name: e.Name}
+
+	for i, v := range e.Values {
+		enum.Values.Add(toUpperSnakeCase(v), uint(i), nil)
+	}
+
+	return enum
+}
+
+func (t *Transformer) transformStruct(pkg *Package, s *scanner.Struct) *Message {
+	msg := &Message{Name: s.Name}
+
+	for i, f := range s.Fields {
+		field := t.transformField(pkg, f, i+1)
+		if field == nil {
+			msg.Reserve(i + 1)
+			report.Warn("field %q of struct %q has an invalid type, ignoring field but reserving its position", f.Name, s.Name)
+			continue
+		}
+
+		msg.Fields = append(msg.Fields, field)
+	}
+
+	return msg
+}
+
+func (t *Transformer) transformField(pkg *Package, field *scanner.Field, pos int) *Field {
+	var typ Type
+	var repeated = field.Type.IsRepeated()
+
+	// []byte is the only repeated type that maps to
+	// a non-repeated type in protobuf, so we handle
+	// it a bit differently.
+	if isByteSlice(field.Type) {
+		typ = NewBasic("bytes")
+		repeated = false
+	} else {
+		typ = t.transformType(pkg, field.Type)
+		if typ == nil {
+			return nil
+		}
+	}
+
+	return &Field{
+		Name:     toLowerSnakeCase(field.Name),
+		Pos:      pos,
+		Type:     typ,
+		Repeated: repeated,
+		Nullable: field.Type.IsNullable(),
+	}
+}
+
+func (t *Transformer) transformType(pkg *Package, typ scanner.Type) Type {
+	switch ty := typ.(type) {
+	case *scanner.Named:
+		protoType := t.findMapping(ty.String())
+		if protoType != nil {
+			pkg.Import(protoType)
+			return protoType.Type()
+		}
+
+		pkg.ImportFromPath(ty.Path)
+		return NewNamed(toProtobufPkg(ty.Path), ty.Name)
+	case *scanner.Basic:
+		protoType := t.findMapping(ty.Name)
+		if protoType != nil {
+			pkg.Import(protoType)
+			return protoType.Type()
+		}
+	case *scanner.Map:
+		return NewMap(
+			t.transformType(pkg, ty.Key),
+			t.transformType(pkg, ty.Value),
+		)
+	}
+
+	// TODO: only way to reach this is with a basic type that is not defined in the
+	// mappings. Probably should panic?
+	return nil
+}
+
+func (t *Transformer) findMapping(name string) *ProtobufType {
+	typ := t.mappings[name]
+	if typ == nil {
+		typ = defaultMappings[name]
+	}
+
+	return typ
+}
+
+func isByteSlice(typ scanner.Type) bool {
+	if t, ok := typ.(*scanner.Basic); ok && typ.IsRepeated() {
+		return t.Name == "byte"
+	}
+	return false
+}
+
+func toProtobufPkg(path string) string {
+	pkg := strings.Map(func(r rune) rune {
+		if r == '/' || r == '.' {
+			return '.'
+		}
+
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			return r
+		}
+
+		return ' '
+	}, path)
+	pkg = strings.Replace(pkg, " ", "", -1)
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	pkg, _, _ = transform.String(t, pkg)
+	return pkg
+}
+
+func toLowerSnakeCase(s string) string {
+	var buf bytes.Buffer
+	for i, r := range s {
+		if unicode.IsUpper(r) && i != 0 {
+			buf.WriteRune('_')
+		}
+		buf.WriteRune(unicode.ToLower(r))
+	}
+	return buf.String()
+}
+
+func toUpperSnakeCase(s string) string {
+	return strings.ToUpper(toLowerSnakeCase(s))
+}

--- a/protobuf/transform.go
+++ b/protobuf/transform.go
@@ -175,10 +175,12 @@ func toProtobufPkg(path string) string {
 
 func toLowerSnakeCase(s string) string {
 	var buf bytes.Buffer
+	var lastWasUpper bool
 	for i, r := range s {
-		if unicode.IsUpper(r) && i != 0 {
+		if unicode.IsUpper(r) && i != 0 && !lastWasUpper {
 			buf.WriteRune('_')
 		}
+		lastWasUpper = unicode.IsUpper(r)
 		buf.WriteRune(unicode.ToLower(r))
 	}
 	return buf.String()

--- a/protobuf/transform_test.go
+++ b/protobuf/transform_test.go
@@ -1,0 +1,282 @@
+package protobuf
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/src-d/proteus/resolver"
+	"github.com/src-d/proteus/scanner"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestToLowerSnakeCase(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"fooBarBaz", "foo_bar_baz"},
+		{"FooBarBaz", "foo_bar_baz"},
+		{"foo1barBaz", "foo1bar_baz"},
+	}
+
+	for _, c := range cases {
+		require.Equal(t, c.expected, toLowerSnakeCase(c.input))
+	}
+}
+
+func TestToUpperSnakeCase(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"FooBarBaz", "FOO_BAR_BAZ"},
+		{"fooBarBaz", "FOO_BAR_BAZ"},
+		{"foo1barBaz", "FOO1BAR_BAZ"},
+	}
+
+	for _, c := range cases {
+		require.Equal(t, c.expected, toUpperSnakeCase(c.input))
+	}
+}
+
+func TestIsByteSlice(t *testing.T) {
+	cases := []struct {
+		t      scanner.Type
+		result bool
+	}{
+		{scanner.NewBasic("byte"), false},
+		{repeated(scanner.NewBasic("byte")), true},
+		{scanner.NewNamed("foo", "Bar"), false},
+	}
+
+	for _, c := range cases {
+		require.Equal(t, c.result, isByteSlice(c.t))
+	}
+}
+
+func TestToProtobufPkg(t *testing.T) {
+	cases := []struct {
+		path string
+		pkg  string
+	}{
+		{"foo", "foo"},
+		{"net/url", "net.url"},
+		{"github.com/foo/bar", "github.com.foo.bar"},
+		{"github.cóm/fòo/bar", "github.com.foo.bar"},
+		{"gopkg.in/go-foo/foo.v1", "gopkg.in.gofoo.foo.v1"},
+	}
+
+	for _, c := range cases {
+		require.Equal(t, c.pkg, toProtobufPkg(c.path))
+	}
+}
+
+type TransformerSuite struct {
+	suite.Suite
+	t *Transformer
+}
+
+func (s *TransformerSuite) SetupTest() {
+	s.t = NewTransformer()
+	s.t.SetMappings(TypeMappings{
+		"url.URL":       &ProtobufType{Name: "string", Basic: true},
+		"time.Duration": &ProtobufType{Name: "uint64", Basic: true},
+	})
+	s.t.SetMappings(nil)
+	s.NotNil(s.t.mappings)
+}
+
+func (s *TransformerSuite) TestFindMapping() {
+	cases := []struct {
+		name         string
+		protobufType string
+		isNil        bool
+	}{
+		{"foo.Bar", "", true},
+		{"url.URL", "string", false},
+		{"time.Duration", "uint64", false},
+		{"time.Time", "Timestamp", false},
+	}
+
+	for _, c := range cases {
+		t := s.t.findMapping(c.name)
+		if c.isNil {
+			s.Nil(t)
+		} else {
+			s.NotNil(t)
+			s.Equal(c.protobufType, t.Name)
+		}
+	}
+}
+
+func (s *TransformerSuite) TestTransformType() {
+	cases := []struct {
+		typ      scanner.Type
+		expected Type
+		imported string
+	}{
+		{
+			scanner.NewNamed("time", "Time"),
+			NewNamed("google.protobuf", "Timestamp"),
+			"google/protobuf/timestamp.proto",
+		},
+		{
+			scanner.NewNamed("foo", "Bar"),
+			NewNamed("foo", "Bar"),
+			"foo/generated.proto",
+		},
+		{
+			scanner.NewBasic("string"),
+			NewBasic("string"),
+			"",
+		},
+		{
+			scanner.NewMap(
+				scanner.NewBasic("string"),
+				scanner.NewBasic("int64"),
+			),
+			NewMap(NewBasic("string"), NewBasic("int64")),
+			"",
+		},
+		{
+			repeated(scanner.NewBasic("int")),
+			NewBasic("int32"),
+			"",
+		},
+	}
+
+	for _, c := range cases {
+		var pkg Package
+		t := s.t.transformType(&pkg, c.typ)
+		s.Equal(c.expected, t)
+
+		if c.imported != "" {
+			s.Equal(1, len(pkg.Imports))
+			s.Equal(c.imported, pkg.Imports[0])
+		}
+	}
+}
+
+func (s *TransformerSuite) TestTransformField() {
+	cases := []struct {
+		name     string
+		typ      scanner.Type
+		expected *Field
+	}{
+		{
+			"Foo",
+			scanner.NewBasic("int"),
+			&Field{Name: "foo", Type: NewBasic("int32"), Nullable: true},
+		},
+		{
+			"Bar",
+			repeated(scanner.NewBasic("byte")),
+			&Field{Name: "bar", Type: NewBasic("bytes"), Nullable: true},
+		},
+		{
+			"BazBar",
+			repeated(scanner.NewBasic("int")),
+			&Field{Name: "baz_bar", Type: NewBasic("int32"), Repeated: true, Nullable: true},
+		},
+		{
+			"Invalid",
+			scanner.NewBasic("complex64"),
+			nil,
+		},
+	}
+
+	for _, c := range cases {
+		f := s.t.transformField(&Package{}, &scanner.Field{
+			Name: c.name,
+			Type: c.typ,
+		}, 0)
+		s.Equal(c.expected, f, c.name)
+	}
+}
+
+func (s *TransformerSuite) TestTransformStruct() {
+	st := &scanner.Struct{
+		Name: "Foo",
+		Fields: []*scanner.Field{
+			&scanner.Field{
+				Name: "Invalid",
+				Type: scanner.NewBasic("complex64"),
+			},
+			&scanner.Field{
+				Name: "Bar",
+				Type: scanner.NewBasic("string"),
+			},
+		},
+	}
+
+	msg := s.t.transformStruct(&Package{}, st)
+	s.Equal("Foo", msg.Name)
+	s.Equal(1, len(msg.Fields), "should have one field")
+	s.Equal(2, msg.Fields[0].Pos)
+	s.Equal(1, len(msg.Reserved), "should have reserved field")
+	s.Equal(1, msg.Reserved[0])
+}
+
+func (s *TransformerSuite) TestTransformEnum() {
+	enum := s.t.transformEnum(&scanner.Enum{
+		Name:   "Foo",
+		Values: []string{"Foo", "Bar", "BarBaz"},
+	})
+
+	s.Equal("Foo", enum.Name)
+	s.Equal(3, len(enum.Values), "should have same number of values")
+	s.assertEnumVal(enum.Values[0], "FOO", 0)
+	s.assertEnumVal(enum.Values[1], "BAR", 1)
+	s.assertEnumVal(enum.Values[2], "BAR_BAZ", 2)
+}
+
+func (s *TransformerSuite) TestTransform() {
+	pkgs := s.fixtures()
+	pkg := s.t.Transform(pkgs[0])
+
+	s.Equal("github.com.srcd.proteus.fixtures", pkg.Name)
+	s.Equal("github.com/src-d/proteus/fixtures", pkg.Path)
+	s.Equal([]string{
+		"google/protobuf/timestamp.proto",
+		"github.com/src-d/proteus/fixtures/subpkg/generated.proto",
+	}, pkg.Imports)
+	s.Equal(1, len(pkg.Enums))
+	s.Equal(4, len(pkg.Messages))
+
+	pkg = s.t.Transform(pkgs[1])
+	s.Equal("github.com.srcd.proteus.fixtures.subpkg", pkg.Name)
+	s.Equal("github.com/src-d/proteus/fixtures/subpkg", pkg.Path)
+	s.Equal([]string(nil), pkg.Imports)
+	s.Equal(0, len(pkg.Enums))
+	s.Equal(1, len(pkg.Messages))
+}
+
+func (s *TransformerSuite) fixtures() []*scanner.Package {
+	sc, err := scanner.New(projectPath("fixtures"), projectPath("fixtures/subpkg"))
+	s.Nil(err)
+	pkgs, err := sc.Scan()
+	s.Nil(err)
+	resolver.New().Resolve(resolver.Packages(pkgs))
+	return pkgs
+}
+
+func (s *TransformerSuite) assertEnumVal(v *EnumValue, name string, val uint) {
+	s.Equal(name, v.Name)
+	s.Equal(val, v.Value)
+}
+
+func TestTransformer(t *testing.T) {
+	suite.Run(t, new(TransformerSuite))
+}
+
+func repeated(t scanner.Type) scanner.Type {
+	t.SetRepeated(true)
+	return t
+}
+
+const project = "github.com/src-d/proteus"
+
+func projectPath(pkg string) string {
+	return filepath.Join(project, pkg)
+}

--- a/protobuf/transform_test.go
+++ b/protobuf/transform_test.go
@@ -18,6 +18,8 @@ func TestToLowerSnakeCase(t *testing.T) {
 		{"fooBarBaz", "foo_bar_baz"},
 		{"FooBarBaz", "foo_bar_baz"},
 		{"foo1barBaz", "foo1bar_baz"},
+		{"fooBAR", "foo_bar"},
+		{"FBar", "fbar"},
 	}
 
 	for _, c := range cases {

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -1,7 +1,6 @@
 package resolver
 
 import (
-	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -10,8 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
-
-var gopath = os.Getenv("GOPATH")
 
 const project = "github.com/src-d/proteus"
 
@@ -150,5 +147,5 @@ func enum(name string, values ...string) *scanner.Enum {
 }
 
 func projectPath(pkg string) string {
-	return filepath.Join(gopath, "src", project, pkg)
+	return filepath.Join(project, pkg)
 }

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -280,7 +280,7 @@ func TestProcessStruct(t *testing.T) {
 func TestScanner(t *testing.T) {
 	require := require.New(t)
 
-	scanner, err := New(projectPath("fixtures"), projectPath("fixtures/subpkg"))
+	scanner, err := New(projectPkg("fixtures"), projectPkg("fixtures/subpkg"))
 	require.Nil(err)
 
 	pkgs, err := scanner.Scan()
@@ -290,10 +290,11 @@ func TestScanner(t *testing.T) {
 	pkg := pkgs[0]
 	subpkg := pkgs[1]
 
-	require.Equal(3, len(pkg.Structs), "pkg")
+	require.Equal(4, len(pkg.Structs), "pkg")
 	assertStruct(t, pkg.Structs[0], "Bar", "Bar", "Baz")
 	assertStruct(t, pkg.Structs[1], "Foo", "Bar", "Baz", "IntList", "IntArray", "Map", "Timestamp", "External", "Duration", "Aliased")
 	assertStruct(t, pkg.Structs[2], "Qux", "A", "B")
+	assertStruct(t, pkg.Structs[3], "Saz", "Point", "Foo")
 
 	require.Equal(1, len(subpkg.Structs), "subpkg")
 	assertStruct(t, subpkg.Structs[0], "Point", "X", "Y")
@@ -348,4 +349,8 @@ func newNamed(path, name string, underlying types.Type) types.Type {
 		underlying,
 	)
 	return types.NewNamed(obj, underlying, nil)
+}
+
+func projectPkg(pkg string) string {
+	return filepath.Join(project, pkg)
 }


### PR DESCRIPTION
Implements transformer from the scanned packages representation to the protobuf representation.
Also it changes the scanner API so it accepts packages instead of paths to packages.