### PR TITLE
Cli interface

### DIFF
--- a/cli/proteus.go
+++ b/cli/proteus.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/src-d/proteus"
+	"github.com/urfave/cli"
+)
+
+func main() {
+	var (
+		packages cli.StringSlice
+		path     string
+	)
+
+	app := cli.NewApp()
+	app.Description = "Generate .proto files from your Go packages."
+	app.Version = "0.1.0"
+	app.Flags = []cli.Flag{
+		cli.StringSliceFlag{
+			Name:  "pkg, p",
+			Usage: "Generate a .proto file for `PACKAGE`. You can use this flag multiple times to specify more than one package.",
+			Value: &packages,
+		},
+		cli.StringFlag{
+			Name:        "folder, f",
+			Usage:       "All generated .proto files will be written in `FOLDER`.",
+			Destination: &path,
+		},
+	}
+
+	app.Action = func(c *cli.Context) error {
+		if path == "" {
+			return errors.New("destination path cannot be empty")
+		}
+
+		if err := checkFolder(path); err != nil {
+			return err
+		}
+
+		if len(packages) == 0 {
+			return errors.New("no package provided, there is nothing to generate")
+		}
+
+		return proteus.GenerateProtos(proteus.Options{
+			BasePath: path,
+			Packages: packages,
+		})
+	}
+
+	app.Run(os.Args)
+}
+
+func checkFolder(p string) error {
+	fi, err := os.Stat(p)
+	switch {
+	case os.IsNotExist(err):
+		return errors.New("folder does not exist, please create it first")
+	case err != nil:
+		return err
+	case !fi.IsDir():
+		return fmt.Errorf("folder is not directory: %s", p)
+	}
+	return nil
+}

--- a/protobuf/transform_test.go
+++ b/protobuf/transform_test.go
@@ -217,7 +217,7 @@ func (s *TransformerSuite) TestTransformStruct() {
 	s.Equal(1, len(msg.Fields), "should have one field")
 	s.Equal(2, msg.Fields[0].Pos)
 	s.Equal(1, len(msg.Reserved), "should have reserved field")
-	s.Equal(1, msg.Reserved[0])
+	s.Equal(uint(1), msg.Reserved[0])
 }
 
 func (s *TransformerSuite) TestTransformEnum() {


### PR DESCRIPTION
Implementation of a very basic CLI interface. Example usage:

```
proteus -p "github.com/src-d/proteus/fixtures" \
-p "github.com/src-d/proteus/fixtures/subpkg" \
-f ~/Desktop/protos
```