### PR TITLE
Plugin interface

### DIFF
--- a/protobuf/gen_test.go
+++ b/protobuf/gen_test.go
@@ -60,9 +60,9 @@ var mockEnum = &Enum{
 	Options: Options{
 		"is_cute": NewLiteralValue("true"),
 	},
-	Values: EnumValues{
-		&EnumValue{Name: "PINK_CUTIE", Value: 0},
-		&EnumValue{Name: "RED_FURY", Value: 1},
+	Values: []*EnumValue{
+		{Name: "PINK_CUTIE", Value: 0},
+		{Name: "RED_FURY", Value: 1},
 	},
 }
 

--- a/protobuf/plugin.go
+++ b/protobuf/plugin.go
@@ -1,0 +1,68 @@
+package protobuf
+
+import "github.com/src-d/proteus/scanner"
+
+// Plugin defines the contract that all plugins must implement.
+// It basically defines some callbacks that will be invoked
+// throughout the whole transforming process.
+// All methods will be called AFTER the element is transformed.
+// So all you can do is modify it, not remove it from the package, etc.
+type Plugin interface {
+	// Package is invoked after all the package has been transformed
+	// into a protobuf package representation.
+	Package(pkg *Package, old *scanner.Package)
+
+	// Message is invoked after a struct is processed. Along with the
+	// message the package will be passed.
+	Message(pkg *Package, m *Message, old *scanner.Struct)
+
+	// Field is invoked after a message field is processed.
+	// Along with the message field the package will be passed.
+	Field(pkg *Package, f *Field, old *scanner.Field)
+
+	// Enum is invoked after an enum is processed. Along with the enum
+	// the package will be passed.
+	Enum(pkg *Package, e *Enum, old *scanner.Enum)
+
+	// EnumValue is invoked after an enum value is processed. Along with
+	// the enum value the package will be passed.
+	EnumValue(pkg *Package, v *EnumValue, old string)
+}
+
+// plugins is a collection of plugins and a Plugin itself. Will call all the
+// methods of the plugins it contains when its methods are called.
+type plugins []Plugin
+
+func (p *plugins) add(pl Plugin) {
+	*p = append(*p, pl)
+}
+
+func (p plugins) Package(pkg *Package, old *scanner.Package) {
+	for _, pl := range p {
+		pl.Package(pkg, old)
+	}
+}
+
+func (p plugins) Message(pkg *Package, msg *Message, old *scanner.Struct) {
+	for _, pl := range p {
+		pl.Message(pkg, msg, old)
+	}
+}
+
+func (p plugins) Field(pkg *Package, f *Field, old *scanner.Field) {
+	for _, pl := range p {
+		pl.Field(pkg, f, old)
+	}
+}
+
+func (p plugins) Enum(pkg *Package, e *Enum, old *scanner.Enum) {
+	for _, pl := range p {
+		pl.Enum(pkg, e, old)
+	}
+}
+
+func (p plugins) EnumValue(pkg *Package, v *EnumValue, old string) {
+	for _, pl := range p {
+		pl.EnumValue(pkg, v, old)
+	}
+}

--- a/protobuf/protobuf.go
+++ b/protobuf/protobuf.go
@@ -195,15 +195,7 @@ func (*Map) isType()   {}
 type Enum struct {
 	Name    string
 	Options Options
-	Values  EnumValues
-}
-
-// EnumValues is a collction of enumeration values.
-type EnumValues []*EnumValue
-
-// Add adds a new value to the list of values of the enum.
-func (v *EnumValues) Add(name string, val uint, options Options) {
-	*v = EnumValues(append(*v, &EnumValue{name, val, options}))
+	Values  []*EnumValue
 }
 
 // EnumValue is a single value in an enumeration.

--- a/protobuf/transform_test.go
+++ b/protobuf/transform_test.go
@@ -193,6 +193,11 @@ func (s *TransformerSuite) TestTransformField() {
 			Name: c.name,
 			Type: c.typ,
 		}, 0)
+
+		if c.expected != nil {
+			c.expected.Options = make(Options)
+		}
+
 		s.Equal(c.expected, f, c.name)
 	}
 }
@@ -221,7 +226,7 @@ func (s *TransformerSuite) TestTransformStruct() {
 }
 
 func (s *TransformerSuite) TestTransformEnum() {
-	enum := s.t.transformEnum(&scanner.Enum{
+	enum := s.t.transformEnum(new(Package), &scanner.Enum{
 		Name:   "Foo",
 		Values: []string{"Foo", "Bar", "BarBaz"},
 	})


### PR DESCRIPTION
Adds the `Plugin` interface on top of which will be later built the plugin system when Go 1.8 and the plugins are released.

Plugin method name suggestions are welcome. I'm not really convinced by any of them.

We still have to figure out how to make the mappings extensible.