### PR TITLE
Generate only code for opt-in entities

### DIFF
--- a/fixtures/bar.go
+++ b/fixtures/bar.go
@@ -3,15 +3,18 @@ package foo
 import "github.com/src-d/proteus/fixtures/subpkg"
 
 // Bar ...
+//proteus:generate
 type Bar struct {
 	Bar uint64
 	Baz Baz
 }
 
 // Baz ...
+//proteus:generate
 type Baz byte
 
 // Saz ...
+//proteus:generate
 type Saz struct {
 	Point subpkg.Point
 	Foo   float64

--- a/fixtures/foo.go
+++ b/fixtures/foo.go
@@ -6,6 +6,7 @@ import (
 )
 
 // Foo ...
+//proteus:generate
 type Foo struct {
 	Bar
 	IntList   []int
@@ -18,6 +19,7 @@ type Foo struct {
 }
 
 // IntList ...
+//proteus:generate
 type IntList []int
 
 // Qux ...

--- a/fixtures/subpkg/foo.go
+++ b/fixtures/subpkg/foo.go
@@ -1,7 +1,11 @@
 package subpkg
 
 // Point ...
+//proteus:generate
 type Point struct {
 	X int
 	Y int
 }
+
+// NotGenerated ...
+type NotGenerated struct{}

--- a/proteus.go
+++ b/proteus.go
@@ -25,7 +25,7 @@ func GenerateProtos(options Options) error {
 	}
 
 	r := resolver.New()
-	r.Resolve(resolver.Packages(pkgs))
+	r.Resolve(pkgs)
 
 	t := protobuf.NewTransformer()
 	g := protobuf.NewGenerator(options.BasePath)

--- a/protobuf/transform_test.go
+++ b/protobuf/transform_test.go
@@ -259,7 +259,7 @@ func (s *TransformerSuite) fixtures() []*scanner.Package {
 	s.Nil(err)
 	pkgs, err := sc.Scan()
 	s.Nil(err)
-	resolver.New().Resolve(resolver.Packages(pkgs))
+	resolver.New().Resolve(pkgs)
 	return pkgs
 }
 

--- a/scanner/context.go
+++ b/scanner/context.go
@@ -1,0 +1,109 @@
+package scanner
+
+import (
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+)
+
+// context holds all the scanning context of a single package. Contains all
+// the enum values we find during the scan as well as some info extracted
+// from the AST that will be needed throughout the process of scanning.
+type context struct {
+	// types holds the type declarations indexed by the type name. The TypeSpec
+	// is guaranteed to include the comments, if any, even though they were on
+	// the GenDecl.
+	types map[string]*ast.TypeSpec
+	// consts holds the const objects indexed by the const name. We store an
+	// object instead of a ValueSpec because the iota of the const is not
+	// available there.
+	consts map[string]*ast.Object
+	// enumValues contains all the values found until a point in time.
+	// It is indexed by qualified type name e.g: time.Time
+	enumValues map[string][]string
+}
+
+// ErrTooManyPackages is returned when there is more than one package in a
+// directory where there should only be one Go package.
+var ErrTooManyPackages = errors.New("more than one package found in a directory")
+
+func buildPackageAST(path string) (pkg *ast.Package, err error) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, filepath.Join(goSrc, path), nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(pkgs) != 1 {
+		return nil, ErrTooManyPackages
+	}
+
+	for _, p := range pkgs {
+		pkg = p
+	}
+
+	return
+}
+
+func newContext(path string) (*context, error) {
+	pkg, err := buildPackageAST(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &context{
+		types:      findPkgTypes(pkg),
+		consts:     findObjectsOfType(pkg, ast.Con),
+		enumValues: make(map[string][]string),
+	}, nil
+}
+
+func findPkgTypes(pkg *ast.Package) map[string]*ast.TypeSpec {
+	f := ast.MergePackageFiles(pkg, 0)
+
+	var types = make(map[string]*ast.TypeSpec)
+	for _, d := range f.Decls {
+		decl := d.(*ast.GenDecl)
+		if decl.Tok == token.TYPE {
+			for _, s := range decl.Specs {
+				spec := s.(*ast.TypeSpec)
+				if spec.Doc == nil {
+					spec.Doc = decl.Doc
+				}
+				types[spec.Name.Name] = spec
+			}
+		}
+	}
+
+	return types
+}
+
+func findObjectsOfType(pkg *ast.Package, kind ast.ObjKind) map[string]*ast.Object {
+	var objects = make(map[string]*ast.Object)
+
+	for _, f := range pkg.Files {
+		for k, o := range f.Scope.Objects {
+			if o.Kind == kind {
+				objects[k] = o
+			}
+		}
+	}
+
+	return objects
+}
+
+const genComment = `//proteus:generate`
+
+func (ctx *context) shouldGenerateType(name string) bool {
+	if typ, ok := ctx.types[name]; ok && typ.Doc != nil {
+		for _, l := range typ.Doc.List {
+			if strings.HasPrefix(l.Text, genComment) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/scanner/importer.go
+++ b/scanner/importer.go
@@ -26,8 +26,9 @@ var (
 // is thread safe.
 // A package is cached after building it the first time.
 type Importer struct {
-	mut             sync.RWMutex
-	cache           map[string]*types.Package
+	mut   sync.RWMutex
+	cache map[string]*types.Package
+
 	defaultImporter types.Importer
 }
 

--- a/scanner/package.go
+++ b/scanner/package.go
@@ -1,0 +1,122 @@
+package scanner
+
+import "fmt"
+
+// Package holds information about a single Go package and
+// a reference of all defined structs and type aliases.
+// A Package is only safe to use once it is resolved.
+type Package struct {
+	Resolved bool
+	Path     string
+	Name     string
+	Structs  []*Struct
+	Enums    []*Enum
+	Aliases  map[string]Type
+}
+
+// Type is the common interface for all possible types supported in protogo.
+// Type is neither a representation of a Go type nor a representation of a
+// protobuf type. Is an intermediate representation to ease future steps in
+// the conversion from Go to protobuf.
+// All types can be repeated (or not).
+type Type interface {
+	SetRepeated(bool)
+	IsRepeated() bool
+}
+
+// BaseType contains the common fields for all the types.
+type BaseType struct {
+	Repeated bool
+}
+
+func newBaseType() *BaseType {
+	return &BaseType{
+		Repeated: false,
+	}
+}
+
+// IsRepeated reports wether the type is repeated or not.
+func (t *BaseType) IsRepeated() bool { return t.Repeated }
+
+// SetRepeated sets the type as repeated or not repeated.
+func (t *BaseType) SetRepeated(v bool) { t.Repeated = v }
+
+// Basic is a basic type, which only is identified by its name.
+type Basic struct {
+	*BaseType
+	Name string
+}
+
+// NewBasic creates a new basic type given its name.
+func NewBasic(name string) Type {
+	return &Basic{
+		newBaseType(),
+		name,
+	}
+}
+
+// Named is non-basic type identified by a name on some package.
+type Named struct {
+	*BaseType
+	Path string
+	Name string
+}
+
+func (n Named) String() string {
+	return fmt.Sprintf("%s.%s", n.Path, n.Name)
+}
+
+// NewNamed creates a new named type given its package path and name.
+func NewNamed(path, name string) Type {
+	return &Named{
+		newBaseType(),
+		path,
+		name,
+	}
+}
+
+// Map is a map type with a key and a value type.
+type Map struct {
+	*BaseType
+	Key   Type
+	Value Type
+}
+
+// NewMap creates a new map type with the given key and value types.
+func NewMap(key, val Type) Type {
+	return &Map{
+		newBaseType(),
+		key,
+		val,
+	}
+}
+
+// Enum consists of a list of possible values.
+type Enum struct {
+	Name   string
+	Values []string
+}
+
+// Struct represents a Go struct with its name and fields.
+// All structs
+type Struct struct {
+	Generate bool
+	Name     string
+	Fields   []*Field
+}
+
+// HasField reports wether a struct has a given field name.
+func (s *Struct) HasField(name string) bool {
+	for _, f := range s.Fields {
+		if f.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// Field contains name and type of a struct field.
+type Field struct {
+	Name string
+	Type Type
+}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -6,135 +6,18 @@ import (
 	"go/types"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
 	"github.com/src-d/proteus/report"
 )
 
-// Package holds information about a single Go package and
-// a reference of all defined structs and type aliases.
-// A Package is only safe to use once it is resolved.
-type Package struct {
-	Resolved bool
-	Path     string
-	Name     string
-	Structs  []*Struct
-	Enums    []*Enum
-	Aliases  map[string]Type
-	values   map[string][]string
-}
-
-// Type is the common interface for all possible types supported in protogo.
-// Type is neither a representation of a Go type nor a representation of a
-// protobuf type. Is an intermediate representation to ease future steps in
-// the conversion from Go to protobuf.
-// All types can be repeated (or not).
-type Type interface {
-	SetRepeated(bool)
-	IsRepeated() bool
-}
-
-// BaseType contains the common fields for all the types.
-type BaseType struct {
-	Repeated bool
-}
-
-func newBaseType() *BaseType {
-	return &BaseType{
-		Repeated: false,
-	}
-}
-
-// IsRepeated reports wether the type is repeated or not.
-func (t *BaseType) IsRepeated() bool { return t.Repeated }
-
-// SetRepeated sets the type as repeated or not repeated.
-func (t *BaseType) SetRepeated(v bool) { t.Repeated = v }
-
-// Basic is a basic type, which only is identified by its name.
-type Basic struct {
-	*BaseType
-	Name string
-}
-
-// NewBasic creates a new basic type given its name.
-func NewBasic(name string) Type {
-	return &Basic{
-		newBaseType(),
-		name,
-	}
-}
-
-// Named is non-basic type identified by a name on some package.
-type Named struct {
-	*BaseType
-	Path string
-	Name string
-}
-
-func (n Named) String() string {
-	return fmt.Sprintf("%s.%s", n.Path, n.Name)
-}
-
-// NewNamed creates a new named type given its package path and name.
-func NewNamed(path, name string) Type {
-	return &Named{
-		newBaseType(),
-		path,
-		name,
-	}
-}
-
-// Map is a map type with a key and a value type.
-type Map struct {
-	*BaseType
-	Key   Type
-	Value Type
-}
-
-// NewMap creates a new map type with the given key and value types.
-func NewMap(key, val Type) Type {
-	return &Map{
-		newBaseType(),
-		key,
-		val,
-	}
-}
-
-// Enum consists of a list of possible values.
-type Enum struct {
-	Name   string
-	Values []string
-}
-
-// Struct represents a Go struct with its name and fields.
-type Struct struct {
-	Name   string
-	Fields []*Field
-}
-
-// HasField reports wether a struct has a given field name.
-func (s *Struct) HasField(name string) bool {
-	for _, f := range s.Fields {
-		if f.Name == name {
-			return true
-		}
-	}
-	return false
-}
-
-// Field contains name and type of a struct field.
-type Field struct {
-	Name string
-	Type Type
-}
-
 // Scanner scans packages looking for Go source files to parse
 // and extract types and structs from.
 type Scanner struct {
 	packages []string
-	importer types.Importer
+	importer *Importer
 }
 
 // ErrNoGoPathSet is the error returned when the GOPATH variable is not
@@ -170,7 +53,7 @@ func New(packages ...string) (*Scanner, error) {
 func (s *Scanner) Scan() ([]*Package, error) {
 	var (
 		pkgs   = make([]*Package, len(s.packages))
-		errors []error
+		errors errorList
 		mut    sync.Mutex
 		wg     = new(sync.WaitGroup)
 	)
@@ -180,34 +63,41 @@ func (s *Scanner) Scan() ([]*Package, error) {
 		go func(p string, i int) {
 			defer wg.Done()
 
-			gopkg, err := s.importer.Import(p)
-			var pkg *Package
-			if err == nil {
-				pkg, err = buildPackage(gopkg)
-			}
+			pkg, err := s.scanPackage(p)
 			mut.Lock()
 			defer mut.Unlock()
 			if err != nil {
-				errors = append(errors, fmt.Errorf("error scanning package %q: %s", p, err))
-			} else {
-				pkgs[i] = pkg
+				errors.add(fmt.Errorf("error scanning package %q: %s", p, err))
+				return
 			}
+
+			pkgs[i] = pkg
 		}(p, i)
 	}
 
 	wg.Wait()
 	if len(errors) > 0 {
-		var lines []string
-		for _, err := range errors {
-			lines = append(lines, err.Error())
-		}
-		return nil, fmt.Errorf(strings.Join(lines, "\n"))
+		return nil, errors.err()
 	}
 
 	return pkgs, nil
 }
 
-func (p *Package) processObject(o types.Object) {
+func (s *Scanner) scanPackage(p string) (*Package, error) {
+	pkg, err := s.importer.Import(p)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, err := newContext(p)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildPackage(ctx, pkg)
+}
+
+func (p *Package) processObject(ctx *context, o types.Object) {
 	n, ok := o.Type().(*types.Named)
 	if !ok || !o.Exported() {
 		return
@@ -216,14 +106,16 @@ func (p *Package) processObject(o types.Object) {
 	switch o.(type) {
 	case *types.Var, *types.Const:
 		if _, ok := n.Underlying().(*types.Basic); ok {
-			p.processEnumValue(o.Name(), n)
+			processEnumValue(ctx, o.Name(), n)
 		}
 		return
 	}
 
 	if s, ok := n.Underlying().(*types.Struct); ok {
-
-		st := processStruct(&Struct{Name: o.Name()}, s)
+		st := processStruct(&Struct{
+			Name:     o.Name(),
+			Generate: ctx.shouldGenerateType(o.Name()),
+		}, s)
 		p.Structs = append(p.Structs, st)
 		return
 	}
@@ -260,9 +152,9 @@ func processType(typ types.Type) (t Type) {
 	return
 }
 
-func (p *Package) processEnumValue(name string, named *types.Named) {
+func processEnumValue(ctx *context, name string, named *types.Named) {
 	typ := objName(named.Obj())
-	p.values[typ] = append(p.values[typ], name)
+	ctx.enumValues[typ] = append(ctx.enumValues[typ], name)
 }
 
 func processStruct(s *Struct, elem *types.Struct) *Struct {
@@ -321,41 +213,83 @@ func findStruct(t types.Type) *types.Struct {
 	}
 }
 
-func (p *Package) collectEnums() {
+func (p *Package) collectEnums(ctx *context) {
 	for k := range p.Aliases {
-		if vals, ok := p.values[k]; ok {
+		if vals, ok := ctx.enumValues[k]; ok {
 			idx := strings.LastIndex(k, ".")
 			name := k[idx+1:]
+			if !ctx.shouldGenerateType(name) {
+				continue
+			}
 
-			p.Enums = append(p.Enums, &Enum{
-				Name:   name,
-				Values: vals,
-			})
-
+			p.Enums = append(p.Enums, newEnum(ctx, name, vals))
 			delete(p.Aliases, k)
 		}
 	}
+}
+
+// newEnum creates a new enum with the given name.
+// The values are looked up in the ast package and only if they are constants
+// they will be added as enum values.
+// All values are guaranteed to be sorted by their iota.
+func newEnum(ctx *context, name string, vals []string) *Enum {
+	enum := &Enum{Name: name}
+	var values enumValues
+	for _, v := range vals {
+		if obj, ok := ctx.consts[v]; ok {
+			values = append(values, enumValue{
+				name: v,
+				pos:  uint(obj.Data.(int)),
+			})
+		}
+	}
+
+	sort.Stable(values)
+
+	for _, v := range values {
+		enum.Values = append(enum.Values, v.name)
+	}
+
+	return enum
+}
+
+type enumValue struct {
+	name string
+	pos  uint
+}
+
+type enumValues []enumValue
+
+func (v enumValues) Swap(i, j int) {
+	v[j], v[i] = v[i], v[j]
+}
+
+func (v enumValues) Len() int {
+	return len(v)
+}
+
+func (v enumValues) Less(i, j int) bool {
+	return v[i].pos < v[j].pos
 }
 
 func isIgnoredField(f *types.Var, tags []string) bool {
 	return !f.Exported() || (len(tags) > 0 && tags[0] == "-")
 }
 
-func buildPackage(gopkg *types.Package) (*Package, error) {
+func buildPackage(ctx *context, gopkg *types.Package) (*Package, error) {
 	objs := objectsInScope(gopkg.Scope())
 
 	pkg := &Package{
 		Path:    removeGoPath(gopkg.Path()),
 		Name:    gopkg.Name(),
-		values:  make(map[string][]string),
 		Aliases: make(map[string]Type),
 	}
 
 	for _, o := range objs {
-		pkg.processObject(o)
+		pkg.processObject(ctx, o)
 	}
 
-	pkg.collectEnums()
+	pkg.collectEnums(ctx)
 	return pkg, nil
 }
 
@@ -372,4 +306,18 @@ func objName(obj types.Object) string {
 
 func removeGoPath(path string) string {
 	return strings.Replace(path, filepath.Join(goPath, "src")+"/", "", -1)
+}
+
+type errorList []error
+
+func (l *errorList) add(err error) {
+	*l = append(*l, err)
+}
+
+func (l errorList) err() error {
+	var lines []string
+	for _, err := range l {
+		lines = append(lines, err.Error())
+	}
+	return errors.New(strings.Join(lines, "\n"))
 }

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -20,7 +20,7 @@ func projectPath(pkg string) string {
 	return filepath.Join(gopath, "src", project, pkg)
 }
 
-func TestProcessType(t *testing.T) {
+func TestScanType(t *testing.T) {
 	cases := []struct {
 		name     string
 		typ      types.Type
@@ -80,11 +80,11 @@ func TestProcessType(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		require.Equal(t, c.expected, processType(c.typ), c.name)
+		require.Equal(t, c.expected, scanType(c.typ), c.name)
 	}
 }
 
-func TestProcessStruct(t *testing.T) {
+func TestScanStruct(t *testing.T) {
 	cases := []struct {
 		name     string
 		elem     *types.Struct
@@ -251,7 +251,7 @@ func TestProcessStruct(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		require.Equal(t, c.expected, processStruct(&Struct{}, c.elem), c.name)
+		require.Equal(t, c.expected, scanStruct(&Struct{}, c.elem), c.name)
 	}
 }
 

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -128,7 +128,7 @@ func TestProcessStruct(t *testing.T) {
 					mkField("Foo", types.Typ[types.Int], false),
 					mkField("Bar", types.Typ[types.String], false),
 				},
-				[]string{"", `proto:"-"`},
+				[]string{"", `proteus:"-"`},
 			),
 			&Struct{
 				Fields: []*Field{
@@ -301,13 +301,14 @@ func TestScanner(t *testing.T) {
 	subpkg := pkgs[1]
 
 	require.Equal(4, len(pkg.Structs), "pkg")
-	assertStruct(t, pkg.Structs[0], "Bar", "Bar", "Baz")
-	assertStruct(t, pkg.Structs[1], "Foo", "Bar", "Baz", "IntList", "IntArray", "Map", "Timestamp", "External", "Duration", "Aliased")
-	assertStruct(t, pkg.Structs[2], "Qux", "A", "B")
-	assertStruct(t, pkg.Structs[3], "Saz", "Point", "Foo")
+	assertStruct(t, pkg.Structs[0], "Bar", true, "Bar", "Baz")
+	assertStruct(t, pkg.Structs[1], "Foo", true, "Bar", "Baz", "IntList", "IntArray", "Map", "Timestamp", "External", "Duration", "Aliased")
+	assertStruct(t, pkg.Structs[2], "Qux", false, "A", "B")
+	assertStruct(t, pkg.Structs[3], "Saz", true, "Point", "Foo")
 
-	require.Equal(1, len(subpkg.Structs), "subpkg")
-	assertStruct(t, subpkg.Structs[0], "Point", "X", "Y")
+	require.Equal(2, len(subpkg.Structs), "subpkg")
+	assertStruct(t, subpkg.Structs[0], "NotGenerated", false)
+	assertStruct(t, subpkg.Structs[1], "Point", true, "X", "Y")
 
 	_, ok := pkg.Aliases[fmt.Sprintf("%s.%s", projectPath("fixtures"), "Baz")]
 	require.False(ok, "Baz should not be an alias anymore")
@@ -322,13 +323,14 @@ func TestScanner(t *testing.T) {
 	)
 }
 
-func assertStruct(t *testing.T, s *Struct, name string, fields ...string) {
+func assertStruct(t *testing.T, s *Struct, name string, generate bool, fields ...string) {
 	require.Equal(
 		t,
 		name,
 		s.Name,
 		"struct name",
 	)
+	require.Equal(t, generate, s.Generate, "struct should be generated")
 
 	require.Equal(t, len(fields), len(s.Fields), "should have same struct fields")
 	for _, f := range fields {

--- a/scanner/tags.go
+++ b/scanner/tags.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-var protoTagRegex = regexp.MustCompile(`proto:"([^"]+)"`)
+var protoTagRegex = regexp.MustCompile(`proteus:"([^"]+)"`)
 
 func findProtoTags(tag string) []string {
 	if !protoTagRegex.MatchString(tag) {


### PR DESCRIPTION
This pull requests takes care of the following tasks:

**New features**

- Implement opt-in of types and enums
  - Structs not opted-in that are required by other structs are still generated.
  - Enums not opted-in are treated as aliases.

**Refactor**

- Removed the `Packages` type, which only added noise to the public facing API.
- Removed all context that is not related to the `scanner.Package` and create a new scanning context.
- `PackagesInfo` is now `packagesInfo` and it's all private because its usage is only meant to be internal.
- Moved scanned entities to their own file for clarity.

**Breaking changes**

- `proto` struct tag is now `proteus`