### PR TITLE
[FEATURE] Add default options to packages

### DIFF
--- a/example/protos/github.com/src-d/proteus/example/generated.proto
+++ b/example/protos/github.com/src-d/proteus/example/generated.proto
@@ -3,6 +3,8 @@ package github.com.srcd.proteus.example;
 
 import "google/protobuf/timestamp.proto";
 
+option go_package = "example";
+
 message Category {
 	int64 id = 1;
 	google.protobuf.Timestamp created_at = 2;

--- a/protobuf/transform.go
+++ b/protobuf/transform.go
@@ -41,8 +41,9 @@ func (t *Transformer) SetMappings(m TypeMappings) {
 // Transform converts a scanned package to a protobuf package.
 func (t *Transformer) Transform(p *scanner.Package) *Package {
 	pkg := &Package{
-		Name: toProtobufPkg(p.Path),
-		Path: p.Path,
+		Name:    toProtobufPkg(p.Path),
+		Path:    p.Path,
+		Options: defaultOptionsForPackage(p),
 	}
 
 	for _, s := range p.Structs {
@@ -188,4 +189,11 @@ func toLowerSnakeCase(s string) string {
 
 func toUpperSnakeCase(s string) string {
 	return strings.ToUpper(toLowerSnakeCase(s))
+}
+func defaultOptionsForPackage(p *scanner.Package) Options {
+	options := make(Options)
+
+	options["go_package"] = NewStringValue(p.Name)
+
+	return options
 }

--- a/protobuf/transform.go
+++ b/protobuf/transform.go
@@ -191,9 +191,7 @@ func toUpperSnakeCase(s string) string {
 	return strings.ToUpper(toLowerSnakeCase(s))
 }
 func defaultOptionsForPackage(p *scanner.Package) Options {
-	options := make(Options)
-
-	options["go_package"] = NewStringValue(p.Name)
-
-	return options
+	return Options{
+		"go_package": NewStringValue(p.Name),
+	}
 }

--- a/protobuf/transform_test.go
+++ b/protobuf/transform_test.go
@@ -239,6 +239,7 @@ func (s *TransformerSuite) TestTransform() {
 
 	s.Equal("github.com.srcd.proteus.fixtures", pkg.Name)
 	s.Equal("github.com/src-d/proteus/fixtures", pkg.Path)
+	s.Equal(NewStringValue("foo"), pkg.Options["go_package"])
 	s.Equal([]string{
 		"google/protobuf/timestamp.proto",
 		"github.com/src-d/proteus/fixtures/subpkg/generated.proto",
@@ -249,6 +250,7 @@ func (s *TransformerSuite) TestTransform() {
 	pkg = s.t.Transform(pkgs[1])
 	s.Equal("github.com.srcd.proteus.fixtures.subpkg", pkg.Name)
 	s.Equal("github.com/src-d/proteus/fixtures/subpkg", pkg.Path)
+	s.Equal(NewStringValue("subpkg"), pkg.Options["go_package"])
 	s.Equal([]string(nil), pkg.Imports)
 	s.Equal(0, len(pkg.Enums))
 	s.Equal(1, len(pkg.Messages))


### PR DESCRIPTION
By default we need to add the `go_package` file option to out output
proto file so gogo/protobuf generates the code in the same package as
the original types.

This updates the example output as well.