### PR TITLE
Resolve functions

### DIFF
--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -48,11 +48,54 @@ func (r *Resolver) isCustomType(n *scanner.Named) bool {
 
 func (r *Resolver) resolvePackage(p *scanner.Package, info *packagesInfo) {
 	for _, s := range p.Structs {
-		s.Fields = r.resolveStructFields(s.Fields, info)
+		r.resolveStruct(s, info)
 	}
+
+	var funcs = make([]*scanner.Func, 0, len(p.Funcs))
+	for _, f := range p.Funcs {
+		if r.resolveFunc(f, info) {
+			funcs = append(funcs, f)
+		} else {
+			report.Warn("func %s had an unresolvable type and it will not be generated", f.Name)
+		}
+	}
+	p.Funcs = funcs
 
 	r.removeUnmarkedStructs(p, info)
 	p.Resolved = true
+}
+
+func (r *Resolver) resolveFunc(f *scanner.Func, info *packagesInfo) bool {
+	f.Input = r.resolveTypeList(f.Input, info)
+	if f.Input == nil {
+		return false
+	}
+
+	f.Output = r.resolveTypeList(f.Output, info)
+	if f.Output == nil {
+		return false
+	}
+
+	if f.Receiver != nil {
+		f.Receiver = r.resolveType(f.Receiver, info)
+		if f.Receiver == nil {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (r *Resolver) resolveTypeList(types []scanner.Type, info *packagesInfo) []scanner.Type {
+	var result = make([]scanner.Type, 0, len(types))
+	for _, t := range types {
+		typ := r.resolveType(t, info)
+		if typ == nil {
+			return nil
+		}
+		result = append(result, typ)
+	}
+	return result
 }
 
 func (r *Resolver) removeUnmarkedStructs(p *scanner.Package, info *packagesInfo) {
@@ -66,17 +109,17 @@ func (r *Resolver) removeUnmarkedStructs(p *scanner.Package, info *packagesInfo)
 	p.Structs = structs
 }
 
-func (r *Resolver) resolveStructFields(fields []*scanner.Field, info *packagesInfo) []*scanner.Field {
-	var result = make([]*scanner.Field, 0, len(fields))
+func (r *Resolver) resolveStruct(s *scanner.Struct, info *packagesInfo) {
+	var result = make([]*scanner.Field, 0, len(s.Fields))
 
-	for _, f := range fields {
+	for _, f := range s.Fields {
 		if typ := r.resolveType(f.Type, info); typ != nil {
 			f.Type = typ
 			result = append(result, f)
 		}
 	}
 
-	return result
+	s.Fields = result
 }
 
 func (r *Resolver) resolveType(typ scanner.Type, info *packagesInfo) (result scanner.Type) {

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -26,6 +26,7 @@ func New() *Resolver {
 		customTypes: map[string]struct{}{
 			"time.Time":     {},
 			"time.Duration": {},
+			"error":         {},
 		},
 	}
 }

--- a/scanner/package.go
+++ b/scanner/package.go
@@ -84,6 +84,9 @@ type Named struct {
 }
 
 func (n Named) String() string {
+	if n.Path == "" {
+		return n.Name
+	}
 	return fmt.Sprintf("%s.%s", n.Path, n.Name)
 }
 


### PR DESCRIPTION
**NOTE:** tests are missing on purpose. Until `Func` functionality is properly implemented in the `scanner`, tests of this can not be implemented as it uses `scanner` to test our fixtures.

The PR will be updated with tests whenever the scanner thing is merged, so please do not merge.

### Caveats
* If a function has an unresolvable type, the function is ignored and not generated (printing a warning)