### PR TITLE
Transform functions into RPC services

### DIFF
--- a/protobuf/gen_test.go
+++ b/protobuf/gen_test.go
@@ -137,6 +137,34 @@ func (s *GenSuite) TestWriteMessage() {
 	s.Equal(expectedMsg, s.buf.String())
 }
 
+var mockRpcs = []*RPC{
+	{
+		Name:   "DoFoo",
+		Input:  NewNamed("foo.bar", "DoFooRequest"),
+		Output: NewNamed("foo.bar", "DoFooResponse"),
+	},
+	{
+		Name:   "DoBar",
+		Input:  NewNamed("foo.bar", "DoBarRequest"),
+		Output: NewNamed("foo.bar", "DoBarResponse"),
+	},
+}
+
+const expectedService = `service BarService {
+	DoFoo (foo.bar.DoFooRequest) returns (foo.bar.DoFooResponse);
+	DoBar (foo.bar.DoBarRequest) returns (foo.bar.DoBarResponse);
+}
+
+`
+
+func (s *GenSuite) TestWriteService() {
+	writeService(s.buf, &Package{
+		Name: "foo.bar",
+		RPCs: mockRpcs,
+	})
+	s.Equal(expectedService, s.buf.String())
+}
+
 var expectedProto = fmt.Sprintf(`syntax = "proto3";
 package foo.bar;
 
@@ -146,7 +174,7 @@ option foo = true;
 
 %s
 %s
-`, expectedMsg, expectedEnum)
+%s`, expectedMsg, expectedEnum, expectedService)
 
 func (s *GenSuite) TestGenerate() {
 	err := s.g.Generate(&Package{
@@ -155,6 +183,7 @@ func (s *GenSuite) TestGenerate() {
 		Messages: []*Message{mockMsg},
 		Enums:    []*Enum{mockEnum},
 		Options:  Options{"foo": NewLiteralValue("true")},
+		RPCs:     mockRpcs,
 	})
 	s.Nil(err)
 

--- a/protobuf/protobuf.go
+++ b/protobuf/protobuf.go
@@ -14,6 +14,7 @@ type Package struct {
 	Options  Options
 	Messages []*Message
 	Enums    []*Enum
+	RPCs     []*RPC
 }
 
 // Import tries to import the given protobuf type to the current package.
@@ -210,5 +211,13 @@ func (v *EnumValues) Add(name string, val uint, options Options) {
 type EnumValue struct {
 	Name    string
 	Value   uint
+	Options Options
+}
+
+// RPC is a single exposed RPC method in the RPC service.
+type RPC struct {
+	Name    string
+	Input   Type
+	Output  Type
 	Options Options
 }

--- a/protobuf/transform.go
+++ b/protobuf/transform.go
@@ -184,6 +184,11 @@ func (t *Transformer) transformField(pkg *Package, field *scanner.Field, pos int
 }
 
 func (t *Transformer) transformType(pkg *Package, typ scanner.Type) Type {
+	if isError(typ) {
+		report.Error("error type is not supported")
+		return nil
+	}
+
 	switch ty := typ.(type) {
 	case *scanner.Named:
 		protoType := t.findMapping(ty.String())
@@ -224,7 +229,7 @@ func (t *Transformer) findMapping(name string) *ProtoType {
 func removeLastError(types []scanner.Type) []scanner.Type {
 	if len(types) > 0 {
 		last := types[len(types)-1]
-		if b, ok := last.(*scanner.Basic); ok && b.Name == "error" {
+		if isError(last) {
 			return types[:len(types)-1]
 		}
 	}
@@ -235,6 +240,13 @@ func removeLastError(types []scanner.Type) []scanner.Type {
 func isNamed(typ scanner.Type) bool {
 	_, ok := typ.(*scanner.Named)
 	return ok
+}
+
+func isError(typ scanner.Type) bool {
+	if err, ok := typ.(*scanner.Named); ok {
+		return err.Path == "" && err.Name == "error"
+	}
+	return false
 }
 
 func isByteSlice(typ scanner.Type) bool {

--- a/protobuf/transform_test.go
+++ b/protobuf/transform_test.go
@@ -230,7 +230,7 @@ func (s *TransformerSuite) TestTransformFuncMultiple() {
 		Output: []scanner.Type{
 			scanner.NewNamed("foo", "Foo"),
 			scanner.NewBasic("bool"),
-			scanner.NewBasic("error"),
+			scanner.NewNamed("", "error"),
 		},
 	}
 	pkg := &Package{Path: "baz"}
@@ -265,7 +265,7 @@ func (s *TransformerSuite) TestTransformFuncInputRegistered() {
 		Output: []scanner.Type{
 			scanner.NewNamed("foo", "Foo"),
 			scanner.NewBasic("bool"),
-			scanner.NewBasic("error"),
+			scanner.NewNamed("", "error"),
 		},
 	}
 	rpc := s.t.transformFunc(&Package{}, fn, nameSet{"DoFooRequest": struct{}{}})
@@ -283,7 +283,7 @@ func (s *TransformerSuite) TestTransformFuncOutputRegistered() {
 		Output: []scanner.Type{
 			scanner.NewNamed("foo", "Foo"),
 			scanner.NewBasic("bool"),
-			scanner.NewBasic("error"),
+			scanner.NewNamed("", "error"),
 		},
 	}
 	rpc := s.t.transformFunc(&Package{}, fn, nameSet{"DoFooResponse": struct{}{}})
@@ -319,7 +319,7 @@ func (s *TransformerSuite) TestTransformFunc1BasicArg() {
 		},
 		Output: []scanner.Type{
 			scanner.NewBasic("bool"),
-			scanner.NewBasic("error"),
+			scanner.NewNamed("", "error"),
 		},
 	}
 	pkg := new(Package)
@@ -350,7 +350,7 @@ func (s *TransformerSuite) TestTransformFunc1NamedArg() {
 		},
 		Output: []scanner.Type{
 			scanner.NewNamed("foo", "Bar"),
-			scanner.NewBasic("error"),
+			scanner.NewNamed("", "error"),
 		},
 	}
 	rpc := s.t.transformFunc(new(Package), fn, nameSet{})
@@ -389,7 +389,7 @@ func (s *TransformerSuite) TestTransformFuncRepeatedSingle() {
 		},
 		Output: []scanner.Type{
 			repeated(scanner.NewBasic("bool")),
-			scanner.NewBasic("error"),
+			scanner.NewNamed("", "error"),
 		},
 	}
 	pkg := new(Package)
@@ -439,13 +439,27 @@ func (s *TransformerSuite) TestTransform() {
 	}, pkg.Imports)
 	s.Equal(1, len(pkg.Enums))
 	s.Equal(4, len(pkg.Messages))
+	s.Equal(0, len(pkg.RPCs))
 
 	pkg = s.t.Transform(pkgs[1])
 	s.Equal("github.com.srcd.proteus.fixtures.subpkg", pkg.Name)
 	s.Equal("github.com/src-d/proteus/fixtures/subpkg", pkg.Path)
 	s.Equal([]string(nil), pkg.Imports)
 	s.Equal(0, len(pkg.Enums))
-	s.Equal(1, len(pkg.Messages))
+	s.Equal(5, len(pkg.Messages))
+
+	var msgs = []string{
+		"Point",
+		"GeneratedRequest",
+		"GeneratedResponse",
+		"Point_GeneratedMethodRequest",
+		"Point_GeneratedMethodOnPointerRequest",
+	}
+	for i, m := range pkg.Messages {
+		s.Equal(msgs[i], m.Name)
+	}
+
+	s.Equal(3, len(pkg.RPCs))
 }
 
 func (s *TransformerSuite) fixtures() []*scanner.Package {

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -48,11 +48,54 @@ func (r *Resolver) isCustomType(n *scanner.Named) bool {
 
 func (r *Resolver) resolvePackage(p *scanner.Package, info *packagesInfo) {
 	for _, s := range p.Structs {
-		s.Fields = r.resolveStructFields(s.Fields, info)
+		r.resolveStruct(s, info)
 	}
+
+	var funcs = make([]*scanner.Func, 0, len(p.Funcs))
+	for _, f := range p.Funcs {
+		if r.resolveFunc(f, info) {
+			funcs = append(funcs, f)
+		} else {
+			report.Warn("func %s had an unresolvable type and it will not be generated", f.Name)
+		}
+	}
+	p.Funcs = funcs
 
 	r.removeUnmarkedStructs(p, info)
 	p.Resolved = true
+}
+
+func (r *Resolver) resolveFunc(f *scanner.Func, info *packagesInfo) bool {
+	f.Input = r.resolveTypeList(f.Input, info)
+	if f.Input == nil {
+		return false
+	}
+
+	f.Output = r.resolveTypeList(f.Output, info)
+	if f.Output == nil {
+		return false
+	}
+
+	if f.Receiver != nil {
+		f.Receiver = r.resolveType(f.Receiver, info)
+		if f.Receiver == nil {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (r *Resolver) resolveTypeList(types []scanner.Type, info *packagesInfo) []scanner.Type {
+	var result = make([]scanner.Type, 0, len(types))
+	for _, t := range types {
+		typ := r.resolveType(t, info)
+		if typ == nil {
+			return nil
+		}
+		result = append(result, typ)
+	}
+	return result
 }
 
 func (r *Resolver) removeUnmarkedStructs(p *scanner.Package, info *packagesInfo) {
@@ -66,17 +109,17 @@ func (r *Resolver) removeUnmarkedStructs(p *scanner.Package, info *packagesInfo)
 	p.Structs = structs
 }
 
-func (r *Resolver) resolveStructFields(fields []*scanner.Field, info *packagesInfo) []*scanner.Field {
-	var result = make([]*scanner.Field, 0, len(fields))
+func (r *Resolver) resolveStruct(s *scanner.Struct, info *packagesInfo) {
+	var result = make([]*scanner.Field, 0, len(s.Fields))
 
-	for _, f := range fields {
+	for _, f := range s.Fields {
 		if typ := r.resolveType(f.Type, info); typ != nil {
 			f.Type = typ
 			result = append(result, f)
 		}
 	}
 
-	return result
+	s.Fields = result
 }
 
 func (r *Resolver) resolveType(typ scanner.Type, info *packagesInfo) (result scanner.Type) {

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -26,6 +26,7 @@ func New() *Resolver {
 		customTypes: map[string]struct{}{
 			"time.Time":     {},
 			"time.Duration": {},
+			"error":         {},
 		},
 	}
 }

--- a/scanner/package.go
+++ b/scanner/package.go
@@ -84,6 +84,9 @@ type Named struct {
 }
 
 func (n Named) String() string {
+	if n.Path == "" {
+		return n.Name
+	}
 	return fmt.Sprintf("%s.%s", n.Path, n.Name)
 }
 


### PR DESCRIPTION
Implements transforming `scanner.Func` into `protobuf.RPC`. One single service is emitted **per package** and all methods and functions are put there.

**NOTE:** is missing some full integration tests for the same reason the resolver is missing them: we need the scanner implementation of scanning functions and methods first. But the core logic is already tested thoroughly.

### Caveats
* There is no way to set per service options right now (because there is no declared service per se. I don't know if we need them for anything, though.