### PR TITLE
Add default option for dropping type declarations

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -6,9 +6,9 @@ It has some entities like the ones you could have on a database.
 To generate the `.proto` you can use the `proteus` binary:
 
 ```
-proteus -p github.com/src-d/proteus/example \
-        -f $GOPATH/src/github.com/src-d/proteus/example/protos \
-        --verbose
+proteus proto -p github.com/src-d/proteus/example \
+              -f $GOPATH/src/github.com/src-d/proteus/example/protos \
+              --verbose
 ```
 
 The generated file will be in:

--- a/example/protos/github.com/src-d/proteus/example/generated.proto
+++ b/example/protos/github.com/src-d/proteus/example/generated.proto
@@ -6,6 +6,7 @@ import "google/protobuf/timestamp.proto";
 option go_package = "example";
 
 message Category {
+	option (gogoproto.drop_type_declaration) = true;
 	int64 id = 1;
 	google.protobuf.Timestamp created_at = 2;
 	google.protobuf.Timestamp updated_at = 3;
@@ -17,11 +18,13 @@ message Category {
 }
 
 message CategoryOptions {
+	option (gogoproto.drop_type_declaration) = true;
 	bool show_prices = 1;
 	bool can_buy = 2;
 }
 
 message Product {
+	option (gogoproto.drop_type_declaration) = true;
 	int64 id = 1;
 	google.protobuf.Timestamp created_at = 2;
 	google.protobuf.Timestamp updated_at = 3;
@@ -33,6 +36,7 @@ message Product {
 }
 
 enum Type {
+	option (gogoproto.enum_drop_type_declaration) = true;
 	PUBLIC = 0;
 	PRIVATE = 1;
 	CUSTOM = 2;

--- a/protobuf/transform.go
+++ b/protobuf/transform.go
@@ -156,9 +156,9 @@ func (t *Transformer) transformEnum(e *scanner.Enum) *Enum {
 }
 
 func defaultOptionsForScannedEnum(e *scanner.Enum) Options {
-	opts := make(Options)
-	opts["(gogoproto.enum_drop_type_declaration)"] = NewLiteralValue("true")
-	return opts
+	return Options{
+		"(gogoproto.enum_drop_type_declaration)": NewLiteralValue("true"),
+	}
 }
 
 func (t *Transformer) transformStruct(pkg *Package, s *scanner.Struct) *Message {
@@ -182,9 +182,9 @@ func (t *Transformer) transformStruct(pkg *Package, s *scanner.Struct) *Message 
 }
 
 func defaultOptionsForScannedMessage(s *scanner.Struct) Options {
-	opts := make(Options)
-	opts["(gogoproto.drop_type_declaration)"] = NewLiteralValue("true")
-	return opts
+	return Options{
+		"(gogoproto.drop_type_declaration)": NewLiteralValue("true"),
+	}
 }
 
 func (t *Transformer) transformField(pkg *Package, field *scanner.Field, pos int) *Field {

--- a/protobuf/transform.go
+++ b/protobuf/transform.go
@@ -143,15 +143,30 @@ func (t *Transformer) createMessageFromTypes(pkg *Package, name string, types []
 }
 
 func (t *Transformer) transformEnum(e *scanner.Enum) *Enum {
-	enum := &Enum{Name: e.Name}
+	enum := &Enum{
+		Name:    e.Name,
+		Options: defaultOptionsForScannedEnum(e),
+	}
+
 	for i, v := range e.Values {
 		enum.Values.Add(toUpperSnakeCase(v), uint(i), nil)
 	}
 	return enum
 }
 
+func defaultOptionsForScannedEnum(e *scanner.Enum) Options {
+	opts := make(Options)
+
+	opts["(gogoproto.enum_drop_type_declaration)"] = NewLiteralValue("true")
+
+	return opts
+}
+
 func (t *Transformer) transformStruct(pkg *Package, s *scanner.Struct) *Message {
-	msg := &Message{Name: s.Name}
+	msg := &Message{
+		Name:    s.Name,
+		Options: defaultOptionsForScannedMessage(s),
+	}
 
 	for i, f := range s.Fields {
 		field := t.transformField(pkg, f, i+1)
@@ -165,6 +180,14 @@ func (t *Transformer) transformStruct(pkg *Package, s *scanner.Struct) *Message 
 	}
 
 	return msg
+}
+
+func defaultOptionsForScannedMessage(s *scanner.Struct) Options {
+	opts := make(Options)
+
+	opts["(gogoproto.drop_type_declaration)"] = NewLiteralValue("true")
+
+	return opts
 }
 
 func (t *Transformer) transformField(pkg *Package, field *scanner.Field, pos int) *Field {

--- a/protobuf/transform.go
+++ b/protobuf/transform.go
@@ -156,9 +156,7 @@ func (t *Transformer) transformEnum(e *scanner.Enum) *Enum {
 
 func defaultOptionsForScannedEnum(e *scanner.Enum) Options {
 	opts := make(Options)
-
 	opts["(gogoproto.enum_drop_type_declaration)"] = NewLiteralValue("true")
-
 	return opts
 }
 
@@ -184,9 +182,7 @@ func (t *Transformer) transformStruct(pkg *Package, s *scanner.Struct) *Message 
 
 func defaultOptionsForScannedMessage(s *scanner.Struct) Options {
 	opts := make(Options)
-
 	opts["(gogoproto.drop_type_declaration)"] = NewLiteralValue("true")
-
 	return opts
 }
 

--- a/protobuf/transform.go
+++ b/protobuf/transform.go
@@ -44,6 +44,7 @@ func (t *Transformer) Transform(p *scanner.Package) *Package {
 	pkg := &Package{
 		Name:    toProtobufPkg(p.Path),
 		Path:    p.Path,
+		Imports: []string{"github.com/src-d/protobuf/gogoproto/gogo.proto"},
 		Options: defaultOptionsForPackage(p),
 	}
 

--- a/protobuf/transform_test.go
+++ b/protobuf/transform_test.go
@@ -218,6 +218,7 @@ func (s *TransformerSuite) TestTransformStruct() {
 	s.Equal(2, msg.Fields[0].Pos)
 	s.Equal(1, len(msg.Reserved), "should have reserved field")
 	s.Equal(uint(1), msg.Reserved[0])
+	s.Equal(NewLiteralValue("true"), msg.Options["(gogoproto.drop_type_declaration)"], "should drop declaration by default")
 }
 
 func (s *TransformerSuite) TestTransformFuncMultiple() {
@@ -425,6 +426,7 @@ func (s *TransformerSuite) TestTransformEnum() {
 	s.assertEnumVal(enum.Values[0], "FOO", 0)
 	s.assertEnumVal(enum.Values[1], "BAR", 1)
 	s.assertEnumVal(enum.Values[2], "BAR_BAZ", 2)
+	s.Equal(NewLiteralValue("true"), enum.Options["(gogoproto.enum_drop_type_declaration)"], "should drop declaration by default")
 }
 
 func (s *TransformerSuite) TestTransform() {

--- a/protobuf/transform_test.go
+++ b/protobuf/transform_test.go
@@ -437,6 +437,7 @@ func (s *TransformerSuite) TestTransform() {
 	s.Equal("github.com/src-d/proteus/fixtures", pkg.Path)
 	s.Equal(NewStringValue("foo"), pkg.Options["go_package"])
 	s.Equal([]string{
+		"github.com/src-d/protobuf/gogoproto/gogo.proto",
 		"google/protobuf/timestamp.proto",
 		"github.com/src-d/proteus/fixtures/subpkg/generated.proto",
 	}, pkg.Imports)
@@ -448,7 +449,7 @@ func (s *TransformerSuite) TestTransform() {
 	s.Equal("github.com.srcd.proteus.fixtures.subpkg", pkg.Name)
 	s.Equal("github.com/src-d/proteus/fixtures/subpkg", pkg.Path)
 	s.Equal(NewStringValue("subpkg"), pkg.Options["go_package"])
-	s.Equal([]string(nil), pkg.Imports)
+	s.Equal([]string{"github.com/src-d/protobuf/gogoproto/gogo.proto"}, pkg.Imports)
 	s.Equal(0, len(pkg.Enums))
 	s.Equal(5, len(pkg.Messages))
 


### PR DESCRIPTION
Add to messages and enums the options for the types to be dropped when
using `src-d/protobuf`

Fix #17 