### PR TITLE
Add customname option to fields if needed.

### DIFF
--- a/protobuf/transform.go
+++ b/protobuf/transform.go
@@ -10,6 +10,8 @@ import (
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
 
+	"github.com/src-d/protobuf/protoc-gen-gogo/generator"
+
 	"github.com/src-d/proteus/report"
 	"github.com/src-d/proteus/scanner"
 )
@@ -208,10 +210,20 @@ func (t *Transformer) transformField(pkg *Package, field *scanner.Field, pos int
 
 	return &Field{
 		Name:     toLowerSnakeCase(field.Name),
+		Options:  defaultOptionsForStructField(field),
 		Pos:      pos,
 		Type:     typ,
 		Repeated: repeated,
 	}
+}
+
+func defaultOptionsForStructField(field *scanner.Field) Options {
+	opts := make(Options)
+	if generator.CamelCase(toLowerSnakeCase(field.Name)) != field.Name {
+		opts["(gogoproto.customname)"] = NewStringValue(field.Name)
+	}
+
+	return opts
 }
 
 func (t *Transformer) transformType(pkg *Package, typ scanner.Type) Type {

--- a/protobuf/transform_test.go
+++ b/protobuf/transform_test.go
@@ -169,17 +169,22 @@ func (s *TransformerSuite) TestTransformField() {
 		{
 			"Foo",
 			scanner.NewBasic("int"),
-			&Field{Name: "foo", Type: NewBasic("int32")},
+			&Field{Name: "foo", Type: NewBasic("int32"), Options: make(Options)},
 		},
 		{
 			"Bar",
 			repeated(scanner.NewBasic("byte")),
-			&Field{Name: "bar", Type: NewBasic("bytes")},
+			&Field{Name: "bar", Type: NewBasic("bytes"), Options: make(Options)},
 		},
 		{
 			"BazBar",
 			repeated(scanner.NewBasic("int")),
-			&Field{Name: "baz_bar", Type: NewBasic("int32"), Repeated: true},
+			&Field{Name: "baz_bar", Type: NewBasic("int32"), Repeated: true, Options: make(Options)},
+		},
+		{
+			"CustomID",
+			scanner.NewBasic("int"),
+			&Field{Name: "custom_id", Type: NewBasic("int32"), Options: Options{"(gogoproto.customname)": NewStringValue("CustomID")}},
 		},
 		{
 			"Invalid",
@@ -216,6 +221,7 @@ func (s *TransformerSuite) TestTransformStruct() {
 	s.Equal("Foo", msg.Name)
 	s.Equal(1, len(msg.Fields), "should have one field")
 	s.Equal(2, msg.Fields[0].Pos)
+	s.Equal(0, len(msg.Fields[0].Options))
 	s.Equal(1, len(msg.Reserved), "should have reserved field")
 	s.Equal(uint(1), msg.Reserved[0])
 	s.Equal(NewLiteralValue("true"), msg.Options["(gogoproto.drop_type_declaration)"], "should drop declaration by default")


### PR DESCRIPTION
Some field names cannot be converted back.

Follow this example:

ID -- snakecasify --> id -- camelcasify --> Id

Whenever this process returns a different result from the original field
name, the `(gogoproto.customname)` option is added to the field.

Fixes #32