### PR TITLE
Do not generate receiver if it is not required

### DIFF
--- a/fixtures/subpkg/foo.go
+++ b/fixtures/subpkg/foo.go
@@ -32,3 +32,12 @@ func (p Point) GeneratedMethod(a int32) *Point {
 func (p *Point) GeneratedMethodOnPointer(a bool) *Point {
 	return p
 }
+
+type MyContainer struct {
+	name string
+}
+
+//proteus:generate
+func (c *MyContainer) Name() string {
+	return c.Name()
+}

--- a/protobuf/transform_test.go
+++ b/protobuf/transform_test.go
@@ -1,6 +1,7 @@
 package protobuf
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -456,20 +457,31 @@ func (s *TransformerSuite) TestTransform() {
 	s.Equal(NewStringValue("subpkg"), pkg.Options["go_package"])
 	s.Equal([]string{"github.com/src-d/protobuf/gogoproto/gogo.proto"}, pkg.Imports)
 	s.Equal(0, len(pkg.Enums))
-	s.Equal(5, len(pkg.Messages))
 
 	var msgs = []string{
-		"Point",
 		"GeneratedRequest",
 		"GeneratedResponse",
-		"Point_GeneratedMethodRequest",
+		"MyContainer_NameRequest",
+		"MyContainer_NameResponse",
+		"Point",
 		"Point_GeneratedMethodOnPointerRequest",
+		"Point_GeneratedMethodRequest",
 	}
-	for i, m := range pkg.Messages {
-		s.Equal(msgs[i], m.Name)
+	s.Equal(len(msgs), len(pkg.Messages))
+	for _, m := range pkg.Messages {
+		s.True(hasString(m.Name, msgs), fmt.Sprintf("should have message %s", m.Name))
 	}
 
-	s.Equal(3, len(pkg.RPCs))
+	s.Equal(4, len(pkg.RPCs))
+}
+
+func hasString(str string, coll []string) bool {
+	for _, s := range coll {
+		if s == str {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *TransformerSuite) fixtures() []*scanner.Package {

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -77,13 +77,6 @@ func (r *Resolver) resolveFunc(f *scanner.Func, info *packagesInfo) bool {
 		return false
 	}
 
-	if f.Receiver != nil {
-		f.Receiver = r.resolveType(f.Receiver, info)
-		if f.Receiver == nil {
-			return false
-		}
-	}
-
 	return true
 }
 

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -108,7 +108,7 @@ func (s *ResolverSuite) TestResolve() {
 	pkgs, err := sc.Scan()
 	s.Nil(err)
 
-	s.Equal(2, len(pkgs[1].Structs), "num of structs in pkg")
+	s.Equal(3, len(pkgs[1].Structs), "num of structs in pkg")
 	s.r.Resolve(pkgs)
 
 	pkg := pkgs[0]
@@ -127,7 +127,7 @@ func (s *ResolverSuite) TestResolve() {
 	s.Equal("int", basic.Name)
 
 	s.Equal(1, len(pkgs[1].Structs), "a struct of subpkg should have been removed")
-	s.Equal(3, len(pkgs[1].Funcs), "num of funcs in subpkg")
+	s.Equal(4, len(pkgs[1].Funcs), "num of funcs in subpkg")
 
 	s.Equal(&scanner.Func{
 		Name: "Generated",
@@ -138,7 +138,7 @@ func (s *ResolverSuite) TestResolve() {
 			scanner.NewBasic("bool"),
 			scanner.NewNamed("", "error"),
 		},
-	}, pkgs[1].Funcs[0])
+	}, findFuncByName("Generated", pkgs[1].Funcs))
 
 	s.Equal(&scanner.Func{
 		Name: "GeneratedMethod",
@@ -149,7 +149,7 @@ func (s *ResolverSuite) TestResolve() {
 			scanner.NewNamed(projectPath("fixtures/subpkg"), "Point"),
 		},
 		Receiver: scanner.NewNamed(projectPath("fixtures/subpkg"), "Point"),
-	}, pkgs[1].Funcs[1])
+	}, findFuncByName("GeneratedMethod", pkgs[1].Funcs))
 
 	s.Equal(&scanner.Func{
 		Name: "GeneratedMethodOnPointer",
@@ -160,7 +160,16 @@ func (s *ResolverSuite) TestResolve() {
 			scanner.NewNamed(projectPath("fixtures/subpkg"), "Point"),
 		},
 		Receiver: scanner.NewNamed(projectPath("fixtures/subpkg"), "Point"),
-	}, pkgs[1].Funcs[2])
+	}, findFuncByName("GeneratedMethodOnPointer", pkgs[1].Funcs))
+
+	s.Equal(&scanner.Func{
+		Name:  "Name",
+		Input: []scanner.Type{},
+		Output: []scanner.Type{
+			scanner.NewBasic("string"),
+		},
+		Receiver: scanner.NewNamed(projectPath("fixtures/subpkg"), "MyContainer"),
+	}, findFuncByName("Name", pkgs[1].Funcs))
 }
 
 func (s *ResolverSuite) assertStruct(st *scanner.Struct, name string, fields ...string) {
@@ -189,4 +198,14 @@ func enum(name string, values ...string) *scanner.Enum {
 
 func projectPath(pkg string) string {
 	return filepath.Join(project, pkg)
+}
+
+func findFuncByName(name string, fns []*scanner.Func) *scanner.Func {
+	for _, f := range fns {
+		if f.Name == name {
+			return f
+		}
+	}
+
+	return nil
 }

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -238,6 +238,11 @@ func (s *subpkgServiceServer) Generated(ctx context.Context, in *GeneratedReques
 	result.Result1, err = Generated(in.Arg1)
 	return
 }
+func (s *subpkgServiceServer) MyContainer_Name(ctx context.Context, in *MyContainer_NameRequest) (result *MyContainer_NameResponse, err error) {
+	result = new(MyContainer_NameResponse)
+	result.Result1 = s.MyContainer.Name()
+	return
+}
 func (s *subpkgServiceServer) Point_GeneratedMethod(ctx context.Context, in *Point_GeneratedMethodRequest) (result *Point, err error) {
 	result = new(Point)
 	result = s.Point.GeneratedMethod(in.Arg1)


### PR DESCRIPTION
When resolving, do not resolve a method receiver if it is not needed for
other reasons.

Fixes #29