### PR TITLE
De-reference input in case of not nullable type

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -179,7 +179,13 @@ func (g *Generator) genMethodCall(ctx *context, rpc *protobuf.RPC) ast.Expr {
 	}
 
 	if !isGenerated(rpc.Input) {
-		call.Args = append(call.Args, ast.NewIdent("in"))
+		var in ast.Expr = ast.NewIdent("in")
+		if !rpc.Input.IsNullable() {
+			in = &ast.StarExpr{
+				X: in,
+			}
+		}
+		call.Args = append(call.Args, in)
 	} else {
 		msg := ctx.findMessage(typeName(rpc.Input))
 		for i := range msg.Fields {

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -60,6 +60,12 @@ const expectedFuncNotGeneratedAndNotNullable = `func (s *FooServer) DoFoo(ctx co
 	return
 }`
 
+const expectedFuncNotGeneratedAndNotNullableIn = `func (s *FooServer) DoFoo(ctx context.Context, in *Foo) (result *Bar, err error) {
+	result = new(Bar)
+	result = DoFoo(*in)
+	return
+}`
+
 const expectedFuncGenerated = `func (s *FooServer) DoFoo(ctx context.Context, in *FooRequest) (result *FooResponse, err error) {
 	result = new(FooResponse)
 	result.Result1, result.Result2, result.Result3 = DoFoo(in.Arg1, in.Arg2, in.Arg3)
@@ -125,6 +131,16 @@ func (s *RPCSuite) TestDeclMethod() {
 				Output: notNullable(protobuf.NewNamed("", "Bar")),
 			},
 			expectedFuncNotGeneratedAndNotNullable,
+		},
+		{
+			"func output not generated and not nullable input",
+			&protobuf.RPC{
+				Name:   "DoFoo",
+				Method: "DoFoo",
+				Input:  notNullable(protobuf.NewNamed("", "Foo")),
+				Output: nullable(protobuf.NewNamed("", "Bar")),
+			},
+			expectedFuncNotGeneratedAndNotNullableIn,
 		},
 		{
 			"func generated",


### PR DESCRIPTION
Generate correct code for function with `func(in T1) T2` signature (no pointers in input).