### PR TITLE
Generate RPC Services from Go interfaces

### DIFF
--- a/example/generated.pb.go
+++ b/example/generated.pb.go
@@ -21,6 +21,16 @@
 		RandomCategoryRequest
 		RandomNumberRequest
 		RandomNumberResponse
+		GetAlphaTimeIRequest
+		GetDurationForLengthCtxIRequest
+		GetDurationForLengthIRequest
+		GetOmegaTimeIRequest
+		GetPhoneIRequest
+		RandomBoolIRequest
+		RandomBoolIResponse
+		RandomCategoryIRequest
+		RandomNumberIRequest
+		RandomNumberIResponse
 */
 package example
 
@@ -201,6 +211,138 @@ func (m *RandomNumberResponse) GetResult1() float64 {
 	return 0
 }
 
+type GetAlphaTimeIRequest struct {
+}
+
+func (m *GetAlphaTimeIRequest) Reset()                    { *m = GetAlphaTimeIRequest{} }
+func (m *GetAlphaTimeIRequest) String() string            { return proto.CompactTextString(m) }
+func (*GetAlphaTimeIRequest) ProtoMessage()               {}
+func (*GetAlphaTimeIRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{13} }
+
+type GetDurationForLengthCtxIRequest struct {
+	Arg1 int64 `protobuf:"varint,1,opt,name=arg1,proto3" json:"arg1,omitempty"`
+}
+
+func (m *GetDurationForLengthCtxIRequest) Reset()         { *m = GetDurationForLengthCtxIRequest{} }
+func (m *GetDurationForLengthCtxIRequest) String() string { return proto.CompactTextString(m) }
+func (*GetDurationForLengthCtxIRequest) ProtoMessage()    {}
+func (*GetDurationForLengthCtxIRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptorGenerated, []int{14}
+}
+
+func (m *GetDurationForLengthCtxIRequest) GetArg1() int64 {
+	if m != nil {
+		return m.Arg1
+	}
+	return 0
+}
+
+type GetDurationForLengthIRequest struct {
+	Arg1 int64 `protobuf:"varint,1,opt,name=arg1,proto3" json:"arg1,omitempty"`
+}
+
+func (m *GetDurationForLengthIRequest) Reset()         { *m = GetDurationForLengthIRequest{} }
+func (m *GetDurationForLengthIRequest) String() string { return proto.CompactTextString(m) }
+func (*GetDurationForLengthIRequest) ProtoMessage()    {}
+func (*GetDurationForLengthIRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptorGenerated, []int{15}
+}
+
+func (m *GetDurationForLengthIRequest) GetArg1() int64 {
+	if m != nil {
+		return m.Arg1
+	}
+	return 0
+}
+
+type GetOmegaTimeIRequest struct {
+}
+
+func (m *GetOmegaTimeIRequest) Reset()                    { *m = GetOmegaTimeIRequest{} }
+func (m *GetOmegaTimeIRequest) String() string            { return proto.CompactTextString(m) }
+func (*GetOmegaTimeIRequest) ProtoMessage()               {}
+func (*GetOmegaTimeIRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{16} }
+
+type GetPhoneIRequest struct {
+}
+
+func (m *GetPhoneIRequest) Reset()                    { *m = GetPhoneIRequest{} }
+func (m *GetPhoneIRequest) String() string            { return proto.CompactTextString(m) }
+func (*GetPhoneIRequest) ProtoMessage()               {}
+func (*GetPhoneIRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{17} }
+
+type RandomBoolIRequest struct {
+}
+
+func (m *RandomBoolIRequest) Reset()                    { *m = RandomBoolIRequest{} }
+func (m *RandomBoolIRequest) String() string            { return proto.CompactTextString(m) }
+func (*RandomBoolIRequest) ProtoMessage()               {}
+func (*RandomBoolIRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{18} }
+
+type RandomBoolIResponse struct {
+	Result1 bool `protobuf:"varint,1,opt,name=result1,proto3" json:"result1,omitempty"`
+}
+
+func (m *RandomBoolIResponse) Reset()                    { *m = RandomBoolIResponse{} }
+func (m *RandomBoolIResponse) String() string            { return proto.CompactTextString(m) }
+func (*RandomBoolIResponse) ProtoMessage()               {}
+func (*RandomBoolIResponse) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{19} }
+
+func (m *RandomBoolIResponse) GetResult1() bool {
+	if m != nil {
+		return m.Result1
+	}
+	return false
+}
+
+type RandomCategoryIRequest struct {
+}
+
+func (m *RandomCategoryIRequest) Reset()                    { *m = RandomCategoryIRequest{} }
+func (m *RandomCategoryIRequest) String() string            { return proto.CompactTextString(m) }
+func (*RandomCategoryIRequest) ProtoMessage()               {}
+func (*RandomCategoryIRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{20} }
+
+type RandomNumberIRequest struct {
+	Arg1 float64 `protobuf:"fixed64,1,opt,name=arg1,proto3" json:"arg1,omitempty"`
+	Arg2 float64 `protobuf:"fixed64,2,opt,name=arg2,proto3" json:"arg2,omitempty"`
+}
+
+func (m *RandomNumberIRequest) Reset()                    { *m = RandomNumberIRequest{} }
+func (m *RandomNumberIRequest) String() string            { return proto.CompactTextString(m) }
+func (*RandomNumberIRequest) ProtoMessage()               {}
+func (*RandomNumberIRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{21} }
+
+func (m *RandomNumberIRequest) GetArg1() float64 {
+	if m != nil {
+		return m.Arg1
+	}
+	return 0
+}
+
+func (m *RandomNumberIRequest) GetArg2() float64 {
+	if m != nil {
+		return m.Arg2
+	}
+	return 0
+}
+
+type RandomNumberIResponse struct {
+	Result1 float64 `protobuf:"fixed64,1,opt,name=result1,proto3" json:"result1,omitempty"`
+}
+
+func (m *RandomNumberIResponse) Reset()                    { *m = RandomNumberIResponse{} }
+func (m *RandomNumberIResponse) String() string            { return proto.CompactTextString(m) }
+func (*RandomNumberIResponse) ProtoMessage()               {}
+func (*RandomNumberIResponse) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{22} }
+
+func (m *RandomNumberIResponse) GetResult1() float64 {
+	if m != nil {
+		return m.Result1
+	}
+	return 0
+}
+
 func init() {
 	proto.RegisterType((*Category)(nil), "gopkg.in.srcd.proteus.v1.example.Category")
 	proto.RegisterType((*MyDuration)(nil), "gopkg.in.srcd.proteus.v1.example.MyDuration")
@@ -215,6 +357,16 @@ func init() {
 	proto.RegisterType((*RandomCategoryRequest)(nil), "gopkg.in.srcd.proteus.v1.example.RandomCategoryRequest")
 	proto.RegisterType((*RandomNumberRequest)(nil), "gopkg.in.srcd.proteus.v1.example.RandomNumberRequest")
 	proto.RegisterType((*RandomNumberResponse)(nil), "gopkg.in.srcd.proteus.v1.example.RandomNumberResponse")
+	proto.RegisterType((*GetAlphaTimeIRequest)(nil), "gopkg.in.srcd.proteus.v1.example.GetAlphaTimeIRequest")
+	proto.RegisterType((*GetDurationForLengthCtxIRequest)(nil), "gopkg.in.srcd.proteus.v1.example.GetDurationForLengthCtxIRequest")
+	proto.RegisterType((*GetDurationForLengthIRequest)(nil), "gopkg.in.srcd.proteus.v1.example.GetDurationForLengthIRequest")
+	proto.RegisterType((*GetOmegaTimeIRequest)(nil), "gopkg.in.srcd.proteus.v1.example.GetOmegaTimeIRequest")
+	proto.RegisterType((*GetPhoneIRequest)(nil), "gopkg.in.srcd.proteus.v1.example.GetPhoneIRequest")
+	proto.RegisterType((*RandomBoolIRequest)(nil), "gopkg.in.srcd.proteus.v1.example.RandomBoolIRequest")
+	proto.RegisterType((*RandomBoolIResponse)(nil), "gopkg.in.srcd.proteus.v1.example.RandomBoolIResponse")
+	proto.RegisterType((*RandomCategoryIRequest)(nil), "gopkg.in.srcd.proteus.v1.example.RandomCategoryIRequest")
+	proto.RegisterType((*RandomNumberIRequest)(nil), "gopkg.in.srcd.proteus.v1.example.RandomNumberIRequest")
+	proto.RegisterType((*RandomNumberIResponse)(nil), "gopkg.in.srcd.proteus.v1.example.RandomNumberIResponse")
 	proto.RegisterEnum("gopkg.in.srcd.proteus.v1.example.Type", Type_name, Type_value)
 }
 
@@ -482,6 +634,301 @@ var _ExampleService_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RandomNumber",
 			Handler:    _ExampleService_RandomNumber_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "gopkg.in/src-d/proteus.v1/example/protos/gopkg.in/src-d/proteus.v1/example/generated.proto",
+}
+
+// Client API for Random service
+
+type RandomClient interface {
+	GetAlphaTimeI(ctx context.Context, in *GetAlphaTimeIRequest, opts ...grpc.CallOption) (*MyTime, error)
+	GetDurationForLengthCtxI(ctx context.Context, in *GetDurationForLengthCtxIRequest, opts ...grpc.CallOption) (*MyDuration, error)
+	GetDurationForLengthI(ctx context.Context, in *GetDurationForLengthIRequest, opts ...grpc.CallOption) (*MyDuration, error)
+	GetOmegaTimeI(ctx context.Context, in *GetOmegaTimeIRequest, opts ...grpc.CallOption) (*MyTime, error)
+	GetPhoneI(ctx context.Context, in *GetPhoneIRequest, opts ...grpc.CallOption) (*Product, error)
+	RandomBoolI(ctx context.Context, in *RandomBoolIRequest, opts ...grpc.CallOption) (*RandomBoolIResponse, error)
+	RandomCategoryI(ctx context.Context, in *RandomCategoryIRequest, opts ...grpc.CallOption) (*gopkg_in_srcd_proteus_v1_example_categories.CategoryOptions, error)
+	RandomNumberI(ctx context.Context, in *RandomNumberIRequest, opts ...grpc.CallOption) (*RandomNumberIResponse, error)
+}
+
+type randomClient struct {
+	cc *grpc.ClientConn
+}
+
+func NewRandomClient(cc *grpc.ClientConn) RandomClient {
+	return &randomClient{cc}
+}
+
+func (c *randomClient) GetAlphaTimeI(ctx context.Context, in *GetAlphaTimeIRequest, opts ...grpc.CallOption) (*MyTime, error) {
+	out := new(MyTime)
+	err := grpc.Invoke(ctx, "/gopkg.in.srcd.proteus.v1.example.Random/GetAlphaTimeI", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *randomClient) GetDurationForLengthCtxI(ctx context.Context, in *GetDurationForLengthCtxIRequest, opts ...grpc.CallOption) (*MyDuration, error) {
+	out := new(MyDuration)
+	err := grpc.Invoke(ctx, "/gopkg.in.srcd.proteus.v1.example.Random/GetDurationForLengthCtxI", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *randomClient) GetDurationForLengthI(ctx context.Context, in *GetDurationForLengthIRequest, opts ...grpc.CallOption) (*MyDuration, error) {
+	out := new(MyDuration)
+	err := grpc.Invoke(ctx, "/gopkg.in.srcd.proteus.v1.example.Random/GetDurationForLengthI", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *randomClient) GetOmegaTimeI(ctx context.Context, in *GetOmegaTimeIRequest, opts ...grpc.CallOption) (*MyTime, error) {
+	out := new(MyTime)
+	err := grpc.Invoke(ctx, "/gopkg.in.srcd.proteus.v1.example.Random/GetOmegaTimeI", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *randomClient) GetPhoneI(ctx context.Context, in *GetPhoneIRequest, opts ...grpc.CallOption) (*Product, error) {
+	out := new(Product)
+	err := grpc.Invoke(ctx, "/gopkg.in.srcd.proteus.v1.example.Random/GetPhoneI", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *randomClient) RandomBoolI(ctx context.Context, in *RandomBoolIRequest, opts ...grpc.CallOption) (*RandomBoolIResponse, error) {
+	out := new(RandomBoolIResponse)
+	err := grpc.Invoke(ctx, "/gopkg.in.srcd.proteus.v1.example.Random/RandomBoolI", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *randomClient) RandomCategoryI(ctx context.Context, in *RandomCategoryIRequest, opts ...grpc.CallOption) (*gopkg_in_srcd_proteus_v1_example_categories.CategoryOptions, error) {
+	out := new(gopkg_in_srcd_proteus_v1_example_categories.CategoryOptions)
+	err := grpc.Invoke(ctx, "/gopkg.in.srcd.proteus.v1.example.Random/RandomCategoryI", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *randomClient) RandomNumberI(ctx context.Context, in *RandomNumberIRequest, opts ...grpc.CallOption) (*RandomNumberIResponse, error) {
+	out := new(RandomNumberIResponse)
+	err := grpc.Invoke(ctx, "/gopkg.in.srcd.proteus.v1.example.Random/RandomNumberI", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Server API for Random service
+
+type RandomServer interface {
+	GetAlphaTimeI(context.Context, *GetAlphaTimeIRequest) (*MyTime, error)
+	GetDurationForLengthCtxI(context.Context, *GetDurationForLengthCtxIRequest) (*MyDuration, error)
+	GetDurationForLengthI(context.Context, *GetDurationForLengthIRequest) (*MyDuration, error)
+	GetOmegaTimeI(context.Context, *GetOmegaTimeIRequest) (*MyTime, error)
+	GetPhoneI(context.Context, *GetPhoneIRequest) (*Product, error)
+	RandomBoolI(context.Context, *RandomBoolIRequest) (*RandomBoolIResponse, error)
+	RandomCategoryI(context.Context, *RandomCategoryIRequest) (*gopkg_in_srcd_proteus_v1_example_categories.CategoryOptions, error)
+	RandomNumberI(context.Context, *RandomNumberIRequest) (*RandomNumberIResponse, error)
+}
+
+func RegisterRandomServer(s *grpc.Server, srv RandomServer) {
+	s.RegisterService(&_Random_serviceDesc, srv)
+}
+
+func _Random_GetAlphaTimeI_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetAlphaTimeIRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RandomServer).GetAlphaTimeI(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gopkg.in.srcd.proteus.v1.example.Random/GetAlphaTimeI",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RandomServer).GetAlphaTimeI(ctx, req.(*GetAlphaTimeIRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Random_GetDurationForLengthCtxI_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetDurationForLengthCtxIRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RandomServer).GetDurationForLengthCtxI(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gopkg.in.srcd.proteus.v1.example.Random/GetDurationForLengthCtxI",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RandomServer).GetDurationForLengthCtxI(ctx, req.(*GetDurationForLengthCtxIRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Random_GetDurationForLengthI_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetDurationForLengthIRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RandomServer).GetDurationForLengthI(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gopkg.in.srcd.proteus.v1.example.Random/GetDurationForLengthI",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RandomServer).GetDurationForLengthI(ctx, req.(*GetDurationForLengthIRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Random_GetOmegaTimeI_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetOmegaTimeIRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RandomServer).GetOmegaTimeI(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gopkg.in.srcd.proteus.v1.example.Random/GetOmegaTimeI",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RandomServer).GetOmegaTimeI(ctx, req.(*GetOmegaTimeIRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Random_GetPhoneI_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetPhoneIRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RandomServer).GetPhoneI(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gopkg.in.srcd.proteus.v1.example.Random/GetPhoneI",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RandomServer).GetPhoneI(ctx, req.(*GetPhoneIRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Random_RandomBoolI_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RandomBoolIRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RandomServer).RandomBoolI(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gopkg.in.srcd.proteus.v1.example.Random/RandomBoolI",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RandomServer).RandomBoolI(ctx, req.(*RandomBoolIRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Random_RandomCategoryI_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RandomCategoryIRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RandomServer).RandomCategoryI(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gopkg.in.srcd.proteus.v1.example.Random/RandomCategoryI",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RandomServer).RandomCategoryI(ctx, req.(*RandomCategoryIRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Random_RandomNumberI_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RandomNumberIRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RandomServer).RandomNumberI(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gopkg.in.srcd.proteus.v1.example.Random/RandomNumberI",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RandomServer).RandomNumberI(ctx, req.(*RandomNumberIRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+var _Random_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "gopkg.in.srcd.proteus.v1.example.Random",
+	HandlerType: (*RandomServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "GetAlphaTimeI",
+			Handler:    _Random_GetAlphaTimeI_Handler,
+		},
+		{
+			MethodName: "GetDurationForLengthCtxI",
+			Handler:    _Random_GetDurationForLengthCtxI_Handler,
+		},
+		{
+			MethodName: "GetDurationForLengthI",
+			Handler:    _Random_GetDurationForLengthI_Handler,
+		},
+		{
+			MethodName: "GetOmegaTimeI",
+			Handler:    _Random_GetOmegaTimeI_Handler,
+		},
+		{
+			MethodName: "GetPhoneI",
+			Handler:    _Random_GetPhoneI_Handler,
+		},
+		{
+			MethodName: "RandomBoolI",
+			Handler:    _Random_RandomBoolI_Handler,
+		},
+		{
+			MethodName: "RandomCategoryI",
+			Handler:    _Random_RandomCategoryI_Handler,
+		},
+		{
+			MethodName: "RandomNumberI",
+			Handler:    _Random_RandomNumberI_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -926,6 +1373,221 @@ func (m *RandomNumberResponse) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
+func (m *GetAlphaTimeIRequest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetAlphaTimeIRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *GetDurationForLengthCtxIRequest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetDurationForLengthCtxIRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Arg1 != 0 {
+		dAtA[i] = 0x8
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(m.Arg1))
+	}
+	return i, nil
+}
+
+func (m *GetDurationForLengthIRequest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetDurationForLengthIRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Arg1 != 0 {
+		dAtA[i] = 0x8
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(m.Arg1))
+	}
+	return i, nil
+}
+
+func (m *GetOmegaTimeIRequest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetOmegaTimeIRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *GetPhoneIRequest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetPhoneIRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *RandomBoolIRequest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RandomBoolIRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *RandomBoolIResponse) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RandomBoolIResponse) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Result1 {
+		dAtA[i] = 0x8
+		i++
+		if m.Result1 {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i++
+	}
+	return i, nil
+}
+
+func (m *RandomCategoryIRequest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RandomCategoryIRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *RandomNumberIRequest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RandomNumberIRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Arg1 != 0 {
+		dAtA[i] = 0x9
+		i++
+		i = encodeFixed64Generated(dAtA, i, uint64(math.Float64bits(float64(m.Arg1))))
+	}
+	if m.Arg2 != 0 {
+		dAtA[i] = 0x11
+		i++
+		i = encodeFixed64Generated(dAtA, i, uint64(math.Float64bits(float64(m.Arg2))))
+	}
+	return i, nil
+}
+
+func (m *RandomNumberIResponse) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RandomNumberIResponse) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Result1 != 0 {
+		dAtA[i] = 0x9
+		i++
+		i = encodeFixed64Generated(dAtA, i, uint64(math.Float64bits(float64(m.Result1))))
+	}
+	return i, nil
+}
+
 func encodeFixed64Generated(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	dAtA[offset+1] = uint8(v >> 8)
@@ -1113,6 +1775,84 @@ func (m *RandomNumberRequest) ProtoSize() (n int) {
 }
 
 func (m *RandomNumberResponse) ProtoSize() (n int) {
+	var l int
+	_ = l
+	if m.Result1 != 0 {
+		n += 9
+	}
+	return n
+}
+
+func (m *GetAlphaTimeIRequest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *GetDurationForLengthCtxIRequest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	if m.Arg1 != 0 {
+		n += 1 + sovGenerated(uint64(m.Arg1))
+	}
+	return n
+}
+
+func (m *GetDurationForLengthIRequest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	if m.Arg1 != 0 {
+		n += 1 + sovGenerated(uint64(m.Arg1))
+	}
+	return n
+}
+
+func (m *GetOmegaTimeIRequest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *GetPhoneIRequest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *RandomBoolIRequest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *RandomBoolIResponse) ProtoSize() (n int) {
+	var l int
+	_ = l
+	if m.Result1 {
+		n += 2
+	}
+	return n
+}
+
+func (m *RandomCategoryIRequest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *RandomNumberIRequest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	if m.Arg1 != 0 {
+		n += 9
+	}
+	if m.Arg2 != 0 {
+		n += 9
+	}
+	return n
+}
+
+func (m *RandomNumberIResponse) ProtoSize() (n int) {
 	var l int
 	_ = l
 	if m.Result1 != 0 {
@@ -2584,6 +3324,618 @@ func (m *RandomNumberResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *GetAlphaTimeIRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetAlphaTimeIRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetAlphaTimeIRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetDurationForLengthCtxIRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetDurationForLengthCtxIRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetDurationForLengthCtxIRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Arg1", wireType)
+			}
+			m.Arg1 = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Arg1 |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetDurationForLengthIRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetDurationForLengthIRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetDurationForLengthIRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Arg1", wireType)
+			}
+			m.Arg1 = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Arg1 |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetOmegaTimeIRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetOmegaTimeIRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetOmegaTimeIRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetPhoneIRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetPhoneIRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetPhoneIRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RandomBoolIRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RandomBoolIRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RandomBoolIRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RandomBoolIResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RandomBoolIResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RandomBoolIResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Result1", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Result1 = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RandomCategoryIRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RandomCategoryIRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RandomCategoryIRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RandomNumberIRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RandomNumberIRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RandomNumberIRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Arg1", wireType)
+			}
+			var v uint64
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += 8
+			v = uint64(dAtA[iNdEx-8])
+			v |= uint64(dAtA[iNdEx-7]) << 8
+			v |= uint64(dAtA[iNdEx-6]) << 16
+			v |= uint64(dAtA[iNdEx-5]) << 24
+			v |= uint64(dAtA[iNdEx-4]) << 32
+			v |= uint64(dAtA[iNdEx-3]) << 40
+			v |= uint64(dAtA[iNdEx-2]) << 48
+			v |= uint64(dAtA[iNdEx-1]) << 56
+			m.Arg1 = float64(math.Float64frombits(v))
+		case 2:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Arg2", wireType)
+			}
+			var v uint64
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += 8
+			v = uint64(dAtA[iNdEx-8])
+			v |= uint64(dAtA[iNdEx-7]) << 8
+			v |= uint64(dAtA[iNdEx-6]) << 16
+			v |= uint64(dAtA[iNdEx-5]) << 24
+			v |= uint64(dAtA[iNdEx-4]) << 32
+			v |= uint64(dAtA[iNdEx-3]) << 40
+			v |= uint64(dAtA[iNdEx-2]) << 48
+			v |= uint64(dAtA[iNdEx-1]) << 56
+			m.Arg2 = float64(math.Float64frombits(v))
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RandomNumberIResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RandomNumberIResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RandomNumberIResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Result1", wireType)
+			}
+			var v uint64
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += 8
+			v = uint64(dAtA[iNdEx-8])
+			v |= uint64(dAtA[iNdEx-7]) << 8
+			v |= uint64(dAtA[iNdEx-6]) << 16
+			v |= uint64(dAtA[iNdEx-5]) << 24
+			v |= uint64(dAtA[iNdEx-4]) << 32
+			v |= uint64(dAtA[iNdEx-3]) << 40
+			v |= uint64(dAtA[iNdEx-2]) << 48
+			v |= uint64(dAtA[iNdEx-1]) << 56
+			m.Result1 = float64(math.Float64frombits(v))
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func skipGenerated(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2694,70 +4046,83 @@ func init() {
 }
 
 var fileDescriptorGenerated = []byte{
-	// 1033 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x56, 0x4f, 0x6f, 0xe3, 0xc4,
-	0x1b, 0xb6, 0xf3, 0xbf, 0x6f, 0xab, 0xfe, 0xda, 0xe9, 0xfe, 0xc9, 0xcf, 0x68, 0x6d, 0xab, 0x07,
-	0x08, 0x88, 0x75, 0x68, 0x58, 0xa0, 0xaa, 0xb6, 0x82, 0x26, 0x2d, 0x55, 0xa5, 0x2d, 0x8d, 0xbc,
-	0x5d, 0x0e, 0x15, 0xa2, 0xb8, 0xf6, 0xe0, 0x5a, 0x8d, 0x3d, 0x66, 0x3c, 0xae, 0x36, 0x07, 0x4e,
-	0x1c, 0x28, 0x7b, 0xe2, 0xd8, 0xcb, 0x4a, 0x45, 0xec, 0x81, 0x8f, 0xc1, 0x71, 0x4f, 0x88, 0x4f,
-	0x10, 0x20, 0xfb, 0x05, 0xb8, 0x21, 0xf5, 0x84, 0xc6, 0x63, 0xa7, 0x69, 0xc9, 0x92, 0x14, 0x8e,
-	0xdc, 0x66, 0xde, 0x99, 0xe7, 0x79, 0xdf, 0xbc, 0xcf, 0xf3, 0x8e, 0x03, 0x7b, 0x2e, 0x09, 0x8f,
-	0x5c, 0xc3, 0x0b, 0xea, 0x11, 0xb5, 0xef, 0x3a, 0xf5, 0x90, 0x12, 0x86, 0xe3, 0xc8, 0x38, 0x5e,
-	0xaa, 0xe3, 0xc7, 0x96, 0x1f, 0x76, 0x70, 0x12, 0x22, 0x51, 0x7d, 0xfc, 0x45, 0x17, 0x07, 0x98,
-	0x5a, 0x0c, 0x3b, 0x46, 0x02, 0x41, 0x7a, 0x06, 0x31, 0x22, 0x6a, 0x8b, 0xa0, 0x40, 0x18, 0x29,
-	0x42, 0xb9, 0xeb, 0x7a, 0xec, 0x30, 0x3e, 0x30, 0x6c, 0xe2, 0xd7, 0x5d, 0xe2, 0x12, 0x91, 0xeb,
-	0x20, 0xfe, 0x3c, 0xd9, 0x25, 0x9b, 0x64, 0x25, 0x08, 0x15, 0xcd, 0x25, 0xc4, 0xcd, 0x2a, 0xe2,
-	0xb7, 0x98, 0xe7, 0xe3, 0x88, 0x59, 0x7e, 0x98, 0x5e, 0xb8, 0x3f, 0xbe, 0x48, 0xdb, 0x62, 0xd8,
-	0x25, 0xd4, 0xc3, 0xd1, 0xd5, 0x7a, 0x15, 0xf5, 0x2a, 0xbd, 0x13, 0x53, 0x8b, 0x79, 0x24, 0x10,
-	0xe7, 0x8b, 0x3f, 0xe5, 0xa1, 0xd2, 0x12, 0xf0, 0x2e, 0xba, 0x05, 0x39, 0xcf, 0xa9, 0xca, 0xba,
-	0x5c, 0xcb, 0x37, 0x4b, 0xfd, 0x9e, 0x96, 0xdb, 0x5a, 0x37, 0x73, 0x9e, 0x83, 0x5a, 0x00, 0x36,
-	0xc5, 0x9c, 0x75, 0xdf, 0x62, 0xd5, 0x9c, 0x2e, 0xd7, 0xa6, 0x1b, 0x8a, 0x21, 0x98, 0x8d, 0x8c,
-	0xd9, 0xd8, 0xcd, 0x0a, 0x6f, 0x56, 0x9e, 0xf7, 0x34, 0xe9, 0xdb, 0x5f, 0x34, 0xd9, 0x9c, 0x4a,
-	0x71, 0x6b, 0x8c, 0x93, 0xc4, 0xa1, 0x93, 0x91, 0xe4, 0xaf, 0x43, 0x92, 0xe2, 0x04, 0x89, 0x83,
-	0x3b, 0x38, 0x25, 0x29, 0x5c, 0x87, 0x24, 0xc5, 0xad, 0x31, 0x84, 0xa0, 0x10, 0x58, 0x3e, 0xae,
-	0x16, 0x75, 0xb9, 0x36, 0x65, 0x26, 0x6b, 0xb4, 0x02, 0x05, 0xd6, 0x0d, 0x71, 0xb5, 0xa4, 0xcb,
-	0xb5, 0xd9, 0xc6, 0xab, 0xc6, 0x38, 0x99, 0x8d, 0xdd, 0x6e, 0x88, 0xcd, 0x04, 0x83, 0x34, 0x28,
-	0xda, 0xa4, 0x43, 0x68, 0xb5, 0xcc, 0x09, 0x9b, 0x53, 0xe7, 0x3d, 0xad, 0xd8, 0xe2, 0x01, 0x53,
-	0xc4, 0xd1, 0x27, 0x50, 0x26, 0x21, 0x6f, 0x7a, 0x54, 0xad, 0x24, 0x25, 0xdf, 0x1f, 0xcf, 0x7f,
-	0xa1, 0xa9, 0x91, 0xe9, 0xb3, 0x23, 0x38, 0x9a, 0x05, 0xfe, 0xa3, 0xcc, 0x8c, 0x72, 0x65, 0xe6,
-	0xe4, 0x4c, 0x93, 0x4e, 0xcf, 0x34, 0xe9, 0xf7, 0xef, 0x34, 0x69, 0xf1, 0x08, 0x60, 0xbb, 0xbb,
-	0x9e, 0x8a, 0x8c, 0xde, 0x87, 0x4a, 0x26, 0x78, 0xa2, 0xeb, 0x74, 0xe3, 0xff, 0x7f, 0xe9, 0x56,
-	0x76, 0x59, 0x34, 0xeb, 0x94, 0x37, 0x6b, 0x00, 0x1a, 0xf4, 0x2a, 0x77, 0xd1, 0xab, 0x95, 0xca,
-	0x49, 0x96, 0xec, 0x33, 0x28, 0x6d, 0x77, 0x79, 0xb7, 0xd1, 0x32, 0x14, 0xb8, 0x71, 0xd3, 0x24,
-	0x93, 0x49, 0x92, 0x20, 0xc6, 0x64, 0xd8, 0x80, 0x62, 0x9b, 0x7a, 0x36, 0x46, 0x0a, 0x54, 0xec,
-	0x98, 0x52, 0x1c, 0xd8, 0xdd, 0x24, 0xc9, 0x94, 0x39, 0xd8, 0xa3, 0x5b, 0x50, 0xb2, 0x7c, 0x12,
-	0x07, 0xc2, 0x9b, 0x79, 0x33, 0xdd, 0x0d, 0xd1, 0xfc, 0x56, 0x80, 0x72, 0x9b, 0x12, 0x27, 0xb6,
-	0xd9, 0x7f, 0xd9, 0xe5, 0x7b, 0x50, 0x0c, 0x79, 0x37, 0xab, 0x25, 0x3d, 0x5f, 0x9b, 0x6e, 0xdc,
-	0x1b, 0x6f, 0xc3, 0xb4, 0x69, 0x46, 0x22, 0xc2, 0x46, 0xc0, 0x68, 0xb7, 0x39, 0xcb, 0xb3, 0x9d,
-	0xf7, 0xb4, 0x52, 0x12, 0x8b, 0x4c, 0x41, 0xc9, 0xf3, 0x31, 0xcb, 0x8d, 0xaa, 0x65, 0x3d, 0xcf,
-	0xf3, 0xf1, 0x35, 0xaa, 0xc3, 0x74, 0xea, 0xe3, 0xee, 0xbe, 0xe7, 0x24, 0xe6, 0xcf, 0x37, 0x67,
-	0xfb, 0x3d, 0x0d, 0x32, 0x4f, 0x6f, 0xad, 0x9b, 0x90, 0x5d, 0xd9, 0x72, 0xd0, 0x36, 0x2c, 0x84,
-	0xd4, 0xf3, 0x2d, 0xda, 0xdd, 0x1f, 0x06, 0x4e, 0xe9, 0x72, 0xad, 0xd8, 0xbc, 0xd3, 0xef, 0x69,
-	0xf3, 0x6d, 0x71, 0x7c, 0x81, 0x3f, 0xef, 0x69, 0x05, 0x2f, 0x60, 0xcb, 0xe6, 0x7c, 0x78, 0xe5,
-	0xc8, 0x51, 0x2c, 0x80, 0x8b, 0xc2, 0xd1, 0x1c, 0xe4, 0x8f, 0x70, 0xe6, 0x1e, 0xbe, 0x44, 0xab,
-	0x50, 0x3c, 0xb6, 0x3a, 0x31, 0x4e, 0xd5, 0x7e, 0x6d, 0x92, 0x7e, 0x78, 0x36, 0x36, 0x05, 0x6a,
-	0x25, 0xb7, 0x2c, 0x0f, 0x79, 0xec, 0x26, 0x2c, 0x6c, 0x62, 0xb6, 0xd6, 0x09, 0x0f, 0x2d, 0x2e,
-	0x8d, 0x89, 0xbf, 0x88, 0x71, 0xc4, 0x16, 0x97, 0xe0, 0x95, 0x4d, 0xcc, 0xb2, 0x21, 0xfb, 0x90,
-	0xd0, 0x07, 0x38, 0x70, 0xd9, 0x61, 0x7a, 0xcc, 0xdb, 0x66, 0x51, 0x77, 0x49, 0xf8, 0xd1, 0x4c,
-	0xd6, 0x8b, 0xf7, 0x40, 0x1d, 0x05, 0x69, 0xb1, 0xc7, 0x7f, 0x87, 0x12, 0xf9, 0x77, 0x7c, 0xec,
-	0x5e, 0xca, 0x3f, 0x0f, 0xff, 0xdb, 0xc4, 0xac, 0x7d, 0x48, 0x82, 0x41, 0xe8, 0x36, 0xdc, 0x34,
-	0xad, 0xc0, 0x21, 0x7e, 0xd6, 0xaa, 0xec, 0x60, 0x15, 0x16, 0xc4, 0xc1, 0x47, 0xb1, 0x7f, 0x80,
-	0xe9, 0xa8, 0x6c, 0xb2, 0xc8, 0x96, 0xc6, 0x1a, 0x49, 0xe7, 0x44, 0xac, 0xb1, 0xf8, 0x16, 0xdc,
-	0xb8, 0x0c, 0x8f, 0x42, 0x12, 0x44, 0x18, 0x55, 0xa1, 0x4c, 0x71, 0x14, 0x77, 0x58, 0x46, 0x91,
-	0x6d, 0xdf, 0xf8, 0x14, 0x0a, 0xfc, 0x21, 0xe5, 0x13, 0xdc, 0x7e, 0xd4, 0x7c, 0xb0, 0xd5, 0x9a,
-	0x93, 0x14, 0x78, 0xf2, 0x54, 0x2f, 0xb5, 0xe3, 0x83, 0x8e, 0x67, 0x73, 0x64, 0xdb, 0xdc, 0xfa,
-	0x78, 0x6d, 0x77, 0x63, 0x4e, 0x56, 0xa6, 0x9f, 0x3c, 0xd5, 0xcb, 0x6d, 0xea, 0x1d, 0x5b, 0x2c,
-	0x41, 0xb4, 0x1e, 0x3d, 0xdc, 0xdd, 0xd9, 0x9e, 0xcb, 0x09, 0x44, 0x2b, 0x8e, 0x18, 0xf1, 0x95,
-	0x99, 0x93, 0xef, 0x55, 0xe9, 0x87, 0x67, 0xaa, 0xf4, 0xe3, 0x33, 0x55, 0x6a, 0xfc, 0x51, 0x82,
-	0xd9, 0x0d, 0x21, 0xdd, 0x43, 0x4c, 0x8f, 0xb9, 0x4f, 0x09, 0xcc, 0x0c, 0xcb, 0x84, 0xde, 0x19,
-	0x2f, 0xfa, 0x08, 0x59, 0x95, 0xda, 0x78, 0x58, 0xfa, 0x34, 0x7e, 0x25, 0xc3, 0x8d, 0x51, 0x72,
-	0xa2, 0xd5, 0x89, 0x32, 0xbf, 0xcc, 0x39, 0xca, 0x9b, 0x93, 0x54, 0x30, 0xf8, 0x12, 0x7c, 0x23,
-	0xc3, 0xed, 0x97, 0x98, 0x0a, 0x7d, 0xf0, 0xcf, 0x0a, 0xb9, 0xf0, 0xe3, 0x35, 0x6b, 0x11, 0x12,
-	0x0c, 0x9c, 0x3a, 0xa1, 0x04, 0x57, 0x9d, 0x7d, 0x0d, 0x09, 0x0e, 0xa1, 0x92, 0xcd, 0x00, 0x5a,
-	0x9a, 0x28, 0xd9, 0xf0, 0xbc, 0x28, 0xaf, 0x4f, 0xfc, 0x4e, 0xa2, 0xaf, 0x65, 0x98, 0xbd, 0x3c,
-	0x5b, 0xe8, 0xbd, 0xf1, 0xe8, 0x91, 0xd3, 0xa8, 0xfc, 0xab, 0x7f, 0x09, 0xe8, 0x4b, 0x98, 0x19,
-	0x1e, 0xc6, 0x49, 0x9a, 0x3c, 0x62, 0xf6, 0x95, 0x77, 0xaf, 0x0b, 0x13, 0x33, 0xdf, 0xbc, 0xf3,
-	0xbc, 0xaf, 0xca, 0x3f, 0xf7, 0x55, 0xf9, 0xd7, 0xbe, 0x2a, 0x9d, 0xbe, 0x50, 0xa5, 0xb3, 0x17,
-	0xaa, 0xbc, 0x57, 0x4e, 0x31, 0x07, 0xa5, 0xe4, 0x33, 0xf6, 0xf6, 0x9f, 0x01, 0x00, 0x00, 0xff,
-	0xff, 0x0c, 0xf3, 0x59, 0xff, 0xac, 0x0b, 0x00, 0x00,
+	// 1242 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x57, 0x5f, 0x6f, 0xdb, 0x54,
+	0x14, 0x8f, 0xf3, 0x3f, 0x27, 0x5d, 0xd7, 0xdd, 0x6d, 0x5d, 0x30, 0x2c, 0x8e, 0xf2, 0x00, 0x01,
+	0x31, 0x87, 0x86, 0xfd, 0xa9, 0xaa, 0x6d, 0xd0, 0x64, 0xa5, 0xb2, 0xb4, 0xd2, 0xc8, 0xeb, 0x78,
+	0xa8, 0x10, 0xc5, 0xb5, 0x2f, 0xae, 0x69, 0x62, 0x7b, 0xf6, 0x75, 0xb5, 0x20, 0x21, 0x21, 0x21,
+	0x44, 0x37, 0x5e, 0x78, 0xec, 0xcb, 0xa4, 0x22, 0xf6, 0xc0, 0xc7, 0xe0, 0x71, 0x4f, 0x88, 0x4f,
+	0x10, 0x20, 0xfb, 0x02, 0xbc, 0x21, 0x95, 0x17, 0x64, 0x5f, 0xdb, 0x49, 0xda, 0xb4, 0x89, 0x03,
+	0x6f, 0xbc, 0xdd, 0x7b, 0xee, 0xfd, 0x9d, 0x73, 0xfc, 0xfb, 0x9d, 0x73, 0x4f, 0x02, 0x9b, 0xaa,
+	0x61, 0xee, 0xaa, 0xbc, 0xa6, 0x57, 0x6d, 0x4b, 0xbe, 0xa6, 0x54, 0x4d, 0xcb, 0x20, 0xd8, 0xb1,
+	0xf9, 0xbd, 0x85, 0x2a, 0x7e, 0x2c, 0xb5, 0xcd, 0x16, 0xf6, 0x4c, 0x86, 0x5d, 0x1d, 0x7f, 0x51,
+	0xc5, 0x3a, 0xb6, 0x24, 0x82, 0x15, 0xde, 0x83, 0xa0, 0x52, 0x00, 0xe1, 0x6d, 0x4b, 0xa6, 0x46,
+	0x8a, 0xe0, 0x7d, 0x04, 0x7b, 0x4d, 0xd5, 0xc8, 0x8e, 0xb3, 0xcd, 0xcb, 0x46, 0xbb, 0xaa, 0x1a,
+	0xaa, 0x41, 0x63, 0x6d, 0x3b, 0x9f, 0x79, 0x3b, 0x6f, 0xe3, 0xad, 0xa8, 0x43, 0x96, 0x53, 0x0d,
+	0x43, 0x0d, 0x32, 0x72, 0x6f, 0x11, 0xad, 0x8d, 0x6d, 0x22, 0xb5, 0x4d, 0xff, 0xc2, 0xed, 0xf1,
+	0x49, 0xca, 0x12, 0xc1, 0xaa, 0x61, 0x69, 0xd8, 0x3e, 0x9e, 0x2f, 0x5b, 0x3c, 0xee, 0x5e, 0x71,
+	0x2c, 0x89, 0x68, 0x86, 0x4e, 0xcf, 0xcb, 0xbf, 0x24, 0x20, 0xdb, 0xa0, 0xf0, 0x0e, 0x9a, 0x87,
+	0xb8, 0xa6, 0x14, 0x98, 0x12, 0x53, 0x49, 0xd4, 0xd3, 0xbd, 0x2e, 0x17, 0x17, 0xee, 0x89, 0x71,
+	0x4d, 0x41, 0x0d, 0x00, 0xd9, 0xc2, 0xae, 0xd7, 0x2d, 0x89, 0x14, 0xe2, 0x25, 0xa6, 0x92, 0xaf,
+	0xb1, 0x3c, 0xf5, 0xcc, 0x07, 0x9e, 0xf9, 0x8d, 0x20, 0xf1, 0x7a, 0xf6, 0x45, 0x97, 0x8b, 0x7d,
+	0xff, 0x1b, 0xc7, 0x88, 0x39, 0x1f, 0xb7, 0x4c, 0x5c, 0x27, 0x8e, 0xa9, 0x04, 0x4e, 0x12, 0x51,
+	0x9c, 0xf8, 0x38, 0xea, 0x44, 0xc1, 0x2d, 0xec, 0x3b, 0x49, 0x46, 0x71, 0xe2, 0xe3, 0x96, 0x09,
+	0x42, 0x90, 0xd4, 0xa5, 0x36, 0x2e, 0xa4, 0x4a, 0x4c, 0x25, 0x27, 0x7a, 0x6b, 0xb4, 0x04, 0x49,
+	0xd2, 0x31, 0x71, 0x21, 0x5d, 0x62, 0x2a, 0xb3, 0xb5, 0xd7, 0xf9, 0x71, 0x32, 0xf3, 0x1b, 0x1d,
+	0x13, 0x8b, 0x1e, 0x06, 0x71, 0x90, 0x92, 0x8d, 0x96, 0x61, 0x15, 0x32, 0xae, 0xc3, 0x7a, 0xee,
+	0xa8, 0xcb, 0xa5, 0x1a, 0xae, 0x41, 0xa4, 0x76, 0xf4, 0x31, 0x64, 0x0c, 0xd3, 0x25, 0xdd, 0x2e,
+	0x64, 0xbd, 0x94, 0x6f, 0x8f, 0xf7, 0xdf, 0xd7, 0x94, 0x0f, 0xf4, 0x59, 0xa7, 0x3e, 0xea, 0x49,
+	0xf7, 0xa3, 0xc4, 0xc0, 0xe5, 0xd2, 0xcc, 0xfe, 0x21, 0x17, 0x3b, 0x38, 0xe4, 0x62, 0x7f, 0xfe,
+	0xc0, 0xc5, 0xca, 0xbb, 0x00, 0x6b, 0x9d, 0x7b, 0xbe, 0xc8, 0xe8, 0x3d, 0xc8, 0x06, 0x82, 0x7b,
+	0xba, 0xe6, 0x6b, 0xaf, 0x9c, 0x60, 0x2b, 0xb8, 0x4c, 0xc9, 0x3a, 0x70, 0xc9, 0x0a, 0x41, 0x21,
+	0x57, 0xf1, 0x3e, 0x57, 0x4b, 0xd9, 0xfd, 0x20, 0xd8, 0xa7, 0x90, 0x5e, 0xeb, 0xb8, 0x6c, 0xa3,
+	0x45, 0x48, 0xba, 0x85, 0xeb, 0x07, 0x99, 0x4c, 0x12, 0x0f, 0x31, 0x26, 0xc2, 0x0a, 0xa4, 0x9a,
+	0x96, 0x26, 0x63, 0xc4, 0x42, 0x56, 0x76, 0x2c, 0x0b, 0xeb, 0x72, 0xc7, 0x0b, 0x92, 0x13, 0xc3,
+	0x3d, 0x9a, 0x87, 0xb4, 0xd4, 0x36, 0x1c, 0x9d, 0xd6, 0x66, 0x42, 0xf4, 0x77, 0x03, 0x6e, 0xfe,
+	0x48, 0x42, 0xa6, 0x69, 0x19, 0x8a, 0x23, 0x93, 0xff, 0x73, 0x95, 0x6f, 0x42, 0xca, 0x74, 0xd9,
+	0x2c, 0xa4, 0x4b, 0x89, 0x4a, 0xbe, 0x76, 0x7d, 0x7c, 0x19, 0xfa, 0xa4, 0xf1, 0x9e, 0x08, 0x2b,
+	0x3a, 0xb1, 0x3a, 0xf5, 0x59, 0x37, 0xda, 0x51, 0x97, 0x4b, 0x7b, 0x36, 0x5b, 0xa4, 0x2e, 0xdd,
+	0x78, 0x44, 0x52, 0xed, 0x42, 0xa6, 0x94, 0x70, 0xe3, 0xb9, 0x6b, 0x54, 0x85, 0xbc, 0x5f, 0xc7,
+	0x9d, 0x2d, 0x4d, 0xf1, 0x8a, 0x3f, 0x51, 0x9f, 0xed, 0x75, 0x39, 0x08, 0x6a, 0x5a, 0xb8, 0x27,
+	0x42, 0x70, 0x45, 0x50, 0xd0, 0x1a, 0x5c, 0x34, 0x2d, 0xad, 0x2d, 0x59, 0x9d, 0xad, 0x41, 0x60,
+	0xae, 0xc4, 0x54, 0x52, 0xf5, 0xab, 0xbd, 0x2e, 0x77, 0xa1, 0x49, 0x8f, 0xfb, 0xf8, 0xa3, 0x2e,
+	0x97, 0xd4, 0x74, 0xb2, 0x28, 0x5e, 0x30, 0x8f, 0x1d, 0x29, 0xac, 0x04, 0xd0, 0x4f, 0x1c, 0xcd,
+	0x41, 0x62, 0x17, 0x07, 0xd5, 0xe3, 0x2e, 0xd1, 0x1d, 0x48, 0xed, 0x49, 0x2d, 0x07, 0xfb, 0x6a,
+	0xbf, 0x31, 0x09, 0x1f, 0x9a, 0x8c, 0x45, 0x8a, 0x5a, 0x8a, 0x2f, 0x32, 0x03, 0x35, 0x76, 0x19,
+	0x2e, 0xae, 0x62, 0xb2, 0xdc, 0x32, 0x77, 0x24, 0x57, 0x1a, 0x11, 0x3f, 0x72, 0xb0, 0x4d, 0xca,
+	0x0b, 0xf0, 0xea, 0x2a, 0x26, 0x41, 0x93, 0x7d, 0x60, 0x58, 0xf7, 0xb1, 0xae, 0x92, 0x1d, 0xff,
+	0xd8, 0xa5, 0x4d, 0xb2, 0xd4, 0x05, 0x5a, 0x8f, 0xa2, 0xb7, 0x2e, 0x5f, 0x87, 0xe2, 0x28, 0x48,
+	0x83, 0x3c, 0x3e, 0x0b, 0x45, 0xe3, 0xaf, 0xb7, 0xb1, 0x3a, 0x14, 0xff, 0x02, 0x9c, 0x5f, 0xc5,
+	0xa4, 0xb9, 0x63, 0xe8, 0xa1, 0xe9, 0x0a, 0x5c, 0x16, 0x25, 0x5d, 0x31, 0xda, 0x01, 0x55, 0xc1,
+	0xc1, 0x1d, 0xb8, 0x48, 0x0f, 0x3e, 0x74, 0xda, 0xdb, 0xd8, 0x1a, 0x15, 0x8d, 0xa1, 0xd1, 0x7c,
+	0x5b, 0xcd, 0x63, 0x8e, 0xda, 0x6a, 0xe5, 0x77, 0xe0, 0xd2, 0x30, 0xdc, 0x36, 0x0d, 0xdd, 0xc6,
+	0xa8, 0x00, 0x19, 0x0b, 0xdb, 0x4e, 0x8b, 0x04, 0x2e, 0x82, 0x6d, 0x79, 0x1e, 0x2e, 0x0d, 0x72,
+	0x26, 0x04, 0x89, 0xdc, 0x00, 0xee, 0x14, 0x06, 0x84, 0xb3, 0x28, 0xa8, 0xc1, 0x6b, 0xa3, 0x60,
+	0x67, 0x62, 0x68, 0x0a, 0x21, 0x6d, 0x61, 0x0a, 0x08, 0xe6, 0x02, 0xde, 0x42, 0xdb, 0x25, 0x40,
+	0xf4, 0x03, 0xeb, 0x86, 0xd1, 0x0a, 0xad, 0xd5, 0x80, 0x35, 0xdf, 0x3a, 0xfa, 0xab, 0xb3, 0xfd,
+	0xaf, 0x2e, 0xc0, 0xfc, 0x30, 0xff, 0xa1, 0xab, 0xbb, 0xc3, 0x0c, 0x0a, 0x51, 0x15, 0x58, 0x08,
+	0x94, 0x0d, 0xf1, 0xe3, 0x24, 0x78, 0xeb, 0x13, 0x48, 0xba, 0xb3, 0xcc, 0x7d, 0x44, 0x9b, 0x0f,
+	0xeb, 0xf7, 0x85, 0xc6, 0x5c, 0x8c, 0x85, 0xa7, 0xcf, 0x4a, 0xe9, 0xa6, 0xb3, 0xdd, 0xd2, 0x64,
+	0x17, 0xd9, 0x14, 0x85, 0x8f, 0x96, 0x37, 0x56, 0xe6, 0x18, 0x36, 0xff, 0xf4, 0x59, 0x29, 0xd3,
+	0xb4, 0xb4, 0x3d, 0x89, 0x78, 0x88, 0xc6, 0xc3, 0x07, 0x1b, 0xeb, 0x6b, 0x73, 0x71, 0x8a, 0x68,
+	0x38, 0x36, 0x31, 0xda, 0xec, 0xcc, 0xfe, 0x8f, 0xc5, 0xd8, 0x4f, 0xcf, 0x8b, 0xb1, 0x9f, 0x9f,
+	0x17, 0x63, 0xb5, 0xbf, 0xd2, 0x30, 0xbb, 0x42, 0xbb, 0xe7, 0x01, 0xb6, 0xf6, 0xdc, 0xa7, 0xc2,
+	0x80, 0x99, 0x41, 0xd5, 0xd1, 0x8d, 0xf1, 0x7d, 0x37, 0xa2, 0xb3, 0xd8, 0xca, 0x78, 0x98, 0x3f,
+	0x9d, 0xbe, 0x66, 0x3c, 0x91, 0x4f, 0x14, 0x06, 0xba, 0x33, 0x51, 0xe4, 0xd3, 0x9a, 0x97, 0x7d,
+	0x7b, 0x92, 0x0c, 0xc2, 0x61, 0xfc, 0x84, 0x81, 0x2b, 0xa7, 0x54, 0x35, 0x7a, 0x7f, 0xba, 0x44,
+	0xfa, 0x4f, 0x42, 0xc4, 0x5c, 0xa8, 0x04, 0x61, 0xd5, 0x4f, 0x28, 0xc1, 0xf1, 0xc7, 0x25, 0x82,
+	0x04, 0x3b, 0x90, 0x0d, 0xda, 0x09, 0x2d, 0x4c, 0x14, 0x6c, 0xf0, 0xc9, 0x62, 0xdf, 0x9c, 0x78,
+	0x54, 0xa1, 0x6f, 0x19, 0x98, 0x1d, 0x6e, 0x2f, 0x74, 0x6b, 0x3c, 0x7a, 0xe4, 0x83, 0xc8, 0xfe,
+	0xab, 0x1f, 0x6a, 0xe8, 0x4b, 0x98, 0x19, 0xec, 0xc6, 0x49, 0x48, 0x1e, 0xf1, 0xfc, 0xb2, 0x37,
+	0xa3, 0xc2, 0x68, 0xcf, 0xd7, 0xfe, 0xce, 0x40, 0x9a, 0x1e, 0xa0, 0x47, 0x70, 0x6e, 0xe8, 0x9d,
+	0x45, 0x37, 0xa3, 0xb5, 0x9c, 0x10, 0x5d, 0xf0, 0xef, 0x18, 0x28, 0x9c, 0xf6, 0x86, 0xa3, 0xe5,
+	0xa9, 0xcb, 0x5d, 0x98, 0xae, 0xde, 0xbf, 0x61, 0xe0, 0xf2, 0xc8, 0xd1, 0x80, 0xee, 0x4e, 0x97,
+	0xca, 0x94, 0x79, 0x50, 0x21, 0xfa, 0xd3, 0x66, 0x42, 0x21, 0x4e, 0x8c, 0xa7, 0x08, 0x42, 0x7c,
+	0x0e, 0xb9, 0x70, 0x90, 0xa1, 0xda, 0xe4, 0xad, 0x27, 0x4c, 0xd1, 0x7b, 0x5f, 0x40, 0x7e, 0x60,
+	0x14, 0xa2, 0xeb, 0x93, 0x56, 0xee, 0xe0, 0x3c, 0x65, 0x6f, 0x44, 0x44, 0xf9, 0x23, 0xee, 0x09,
+	0x03, 0xe7, 0x8f, 0x8d, 0x55, 0xb4, 0x18, 0xb5, 0xf1, 0x85, 0xff, 0xa6, 0xf3, 0xbf, 0x62, 0xe0,
+	0xdc, 0xd0, 0x20, 0x46, 0x11, 0x9b, 0x38, 0xcc, 0xe3, 0x56, 0x64, 0x1c, 0xa5, 0xa3, 0x7e, 0xf5,
+	0x45, 0xaf, 0xc8, 0xfc, 0xda, 0x2b, 0x32, 0xbf, 0xf7, 0x8a, 0xb1, 0x83, 0x97, 0xc5, 0xd8, 0xe1,
+	0xcb, 0x22, 0xb3, 0x99, 0xf1, 0x41, 0xdb, 0x69, 0xef, 0x7f, 0xc4, 0xbb, 0xff, 0x04, 0x00, 0x00,
+	0xff, 0xff, 0x46, 0xe6, 0xca, 0x0d, 0x2d, 0x11, 0x00, 0x00,
 }

--- a/example/models.go
+++ b/example/models.go
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/src-d/proteus.v1/example/categories"
 )
 
-//go:generate proteus -p gopkg.in/src-d/proteus.v1/example -f $GOPATH/src/gopkg.in/src-d/proteus.v1/example/protos
+//go:generate proteus -verbose -p gopkg.in/src-d/proteus.v1/example -f $GOPATH/src/gopkg.in/src-d/proteus.v1/example/protos
 
 //proteus:generate
 type Product struct {
@@ -171,3 +171,18 @@ func GetPhone() *Product {
 func RandomBool() bool {
 	return true // Truly random. Selected by flipping a coin... once.
 }
+
+//proteus:generate
+type Random interface {
+	RandomNumberI(mean, std float64) float64
+	RandomCategoryI() categories.CategoryOptions
+	GetAlphaTimeI() MyTime
+	GetOmegaTimeI() (*MyTime, error)
+	GetDurationForLengthI(meters int64) *MyDuration
+	GetDurationForLengthCtxI(ctx context.Context, meters int64) (*MyDuration, error)
+	GetPhoneI() *Product
+	RandomBoolI() bool
+}
+
+//proteus:generate
+type EmptyService interface{}

--- a/example/protos/gopkg.in/src-d/proteus.v1/example/generated.proto
+++ b/example/protos/gopkg.in/src-d/proteus.v1/example/generated.proto
@@ -88,6 +88,42 @@ message RandomNumberResponse {
 	double result1 = 1;
 }
 
+message GetAlphaTimeIRequest {
+}
+
+message GetDurationForLengthCtxIRequest {
+	int64 arg1 = 1;
+}
+
+message GetDurationForLengthIRequest {
+	int64 arg1 = 1;
+}
+
+message GetOmegaTimeIRequest {
+}
+
+message GetPhoneIRequest {
+}
+
+message RandomBoolIRequest {
+}
+
+message RandomBoolIResponse {
+	bool result1 = 1;
+}
+
+message RandomCategoryIRequest {
+}
+
+message RandomNumberIRequest {
+	double arg1 = 1;
+	double arg2 = 2;
+}
+
+message RandomNumberIResponse {
+	double result1 = 1;
+}
+
 // Type will be transformed into an enum.
 enum Type {
 	option (gogoproto.enumdecl) = false;
@@ -106,5 +142,16 @@ service ExampleService {
 	rpc GetPhone (gopkg.in.srcd.proteus.v1.example.GetPhoneRequest) returns (gopkg.in.srcd.proteus.v1.example.Product);
 	rpc RandomCategory (gopkg.in.srcd.proteus.v1.example.RandomCategoryRequest) returns (gopkg.in.srcd.proteus.v1.example.categories.CategoryOptions);
 	rpc RandomNumber (gopkg.in.srcd.proteus.v1.example.RandomNumberRequest) returns (gopkg.in.srcd.proteus.v1.example.RandomNumberResponse);
+}
+
+service Random {
+	rpc GetAlphaTimeI (gopkg.in.srcd.proteus.v1.example.GetAlphaTimeIRequest) returns (gopkg.in.srcd.proteus.v1.example.MyTime);
+	rpc GetDurationForLengthCtxI (gopkg.in.srcd.proteus.v1.example.GetDurationForLengthCtxIRequest) returns (gopkg.in.srcd.proteus.v1.example.MyDuration);
+	rpc GetDurationForLengthI (gopkg.in.srcd.proteus.v1.example.GetDurationForLengthIRequest) returns (gopkg.in.srcd.proteus.v1.example.MyDuration);
+	rpc GetOmegaTimeI (gopkg.in.srcd.proteus.v1.example.GetOmegaTimeIRequest) returns (gopkg.in.srcd.proteus.v1.example.MyTime);
+	rpc GetPhoneI (gopkg.in.srcd.proteus.v1.example.GetPhoneIRequest) returns (gopkg.in.srcd.proteus.v1.example.Product);
+	rpc RandomBoolI (gopkg.in.srcd.proteus.v1.example.RandomBoolIRequest) returns (gopkg.in.srcd.proteus.v1.example.RandomBoolIResponse);
+	rpc RandomCategoryI (gopkg.in.srcd.proteus.v1.example.RandomCategoryIRequest) returns (gopkg.in.srcd.proteus.v1.example.categories.CategoryOptions);
+	rpc RandomNumberI (gopkg.in.srcd.proteus.v1.example.RandomNumberIRequest) returns (gopkg.in.srcd.proteus.v1.example.RandomNumberIResponse);
 }
 

--- a/example/server.proteus.go
+++ b/example/server.proteus.go
@@ -1,7 +1,9 @@
 package example
 
 import (
+	"context"
 	xcontext "golang.org/x/net/context"
+	"google.golang.org/grpc"
 	"gopkg.in/src-d/proteus.v1/example/categories"
 )
 
@@ -47,4 +49,99 @@ func (s *exampleServiceServer) RandomNumber(ctx xcontext.Context, in *RandomNumb
 	result = new(RandomNumberResponse)
 	result.Result1 = RandomNumber(in.Arg1, in.Arg2)
 	return
+}
+
+var _ RandomServer = (*randomServer)(nil)
+
+type randomServer struct {
+	Random Random
+}
+
+func NewRandomServer(s Random) RandomServer {
+	return &randomServer{Random: s}
+}
+func (s *randomServer) GetAlphaTimeI(ctx xcontext.Context, in *GetAlphaTimeIRequest) (result *MyTime, err error) {
+	result = new(MyTime)
+	aux := s.Random.GetAlphaTimeI()
+	result = &aux
+	return
+}
+func (s *randomServer) GetDurationForLengthCtxI(ctx xcontext.Context, in *GetDurationForLengthCtxIRequest) (result *MyDuration, err error) {
+	result = new(MyDuration)
+	result, err = s.Random.GetDurationForLengthCtxI(ctx, in.Arg1)
+	return
+}
+func (s *randomServer) GetDurationForLengthI(ctx xcontext.Context, in *GetDurationForLengthIRequest) (result *MyDuration, err error) {
+	result = new(MyDuration)
+	result = s.Random.GetDurationForLengthI(in.Arg1)
+	return
+}
+func (s *randomServer) GetOmegaTimeI(ctx xcontext.Context, in *GetOmegaTimeIRequest) (result *MyTime, err error) {
+	result = new(MyTime)
+	result, err = s.Random.GetOmegaTimeI()
+	return
+}
+func (s *randomServer) GetPhoneI(ctx xcontext.Context, in *GetPhoneIRequest) (result *Product, err error) {
+	result = new(Product)
+	result = s.Random.GetPhoneI()
+	return
+}
+func (s *randomServer) RandomBoolI(ctx xcontext.Context, in *RandomBoolIRequest) (result *RandomBoolIResponse, err error) {
+	result = new(RandomBoolIResponse)
+	result.Result1 = s.Random.RandomBoolI()
+	return
+}
+func (s *randomServer) RandomCategoryI(ctx xcontext.Context, in *RandomCategoryIRequest) (result *categories.CategoryOptions, err error) {
+	result = new(categories.CategoryOptions)
+	aux := s.Random.RandomCategoryI()
+	result = &aux
+	return
+}
+func (s *randomServer) RandomNumberI(ctx xcontext.Context, in *RandomNumberIRequest) (result *RandomNumberIResponse, err error) {
+	result = new(RandomNumberIResponse)
+	result.Result1 = s.Random.RandomNumberI(in.Arg1, in.Arg2)
+	return
+}
+
+var _ Random = (*randomRemote)(nil)
+
+type randomRemote struct {
+	Random RandomClient
+	opts   []grpc.CallOption
+}
+
+func NewRandomRemote(s RandomClient, opts ...grpc.CallOption) Random {
+	return &randomRemote{Random: s, opts: opts}
+}
+func (s *randomRemote) GetAlphaTimeI() MyTime {
+	resp, _ := s.Random.GetAlphaTimeI(context.TODO(), &GetAlphaTimeIRequest{}, s.opts...)
+	return *resp
+}
+func (s *randomRemote) GetDurationForLengthCtxI(ctx context.Context, meters int64) (*MyDuration, error) {
+	resp, err := s.Random.GetDurationForLengthCtxI(ctx, &GetDurationForLengthCtxIRequest{Arg1: meters}, s.opts...)
+	return resp, err
+}
+func (s *randomRemote) GetDurationForLengthI(meters int64) *MyDuration {
+	resp, _ := s.Random.GetDurationForLengthI(context.TODO(), &GetDurationForLengthIRequest{Arg1: meters}, s.opts...)
+	return resp
+}
+func (s *randomRemote) GetOmegaTimeI() (*MyTime, error) {
+	resp, err := s.Random.GetOmegaTimeI(context.TODO(), &GetOmegaTimeIRequest{}, s.opts...)
+	return resp, err
+}
+func (s *randomRemote) GetPhoneI() *Product {
+	resp, _ := s.Random.GetPhoneI(context.TODO(), &GetPhoneIRequest{}, s.opts...)
+	return resp
+}
+func (s *randomRemote) RandomBoolI() bool {
+	resp, _ := s.Random.RandomBoolI(context.TODO(), &RandomBoolIRequest{}, s.opts...)
+	return resp.Result1
+}
+func (s *randomRemote) RandomCategoryI() categories.CategoryOptions {
+	resp, _ := s.Random.RandomCategoryI(context.TODO(), &RandomCategoryIRequest{}, s.opts...)
+	return *resp
+}
+func (s *randomRemote) RandomNumberI(mean float64, std float64) float64 {
+	resp, _ := s.Random.RandomNumberI(context.TODO(), &RandomNumberIRequest{Arg1: mean, Arg2: std}, s.opts...)
+	return resp.Result1
 }

--- a/fixtures/subpkg/foo.go
+++ b/fixtures/subpkg/foo.go
@@ -51,7 +51,7 @@ func (c *MyContainer) Name() string {
 
 // Svc ...
 //proteus:generate
-type Svc interface{
+type Svc interface {
 	Name() string
 	GenArgs(x, y int) *Point
 	GenArgsErr(x, y int) (*Point, error)

--- a/fixtures/subpkg/foo.go
+++ b/fixtures/subpkg/foo.go
@@ -48,3 +48,14 @@ type MyContainer struct {
 func (c *MyContainer) Name() string {
 	return c.Name()
 }
+
+// Svc ...
+//proteus:generate
+type Svc interface{
+	Name() string
+	GenArgs(x, y int) *Point
+	GenArgsErr(x, y int) (*Point, error)
+	GenRet(s *Point) (x, y int)
+	GenRetErr(s *Point) (x, y int, err error)
+	GenVar(s string, p ...*Point) error
+}

--- a/protobuf/gen.go
+++ b/protobuf/gen.go
@@ -43,8 +43,8 @@ func (g *Generator) Generate(pkg *Package) error {
 		buf.WriteRune('\n')
 	}
 
-	if len(pkg.RPCs) > 0 {
-		writeService(&buf, pkg)
+	for _, svc := range pkg.Services {
+		writeService(&buf, svc)
 	}
 
 	return g.writeFile(pkg.Path, buf.Bytes())
@@ -171,9 +171,9 @@ func writeDocs(buf *bytes.Buffer, docs []string, indent bool) {
 	}
 }
 
-func writeService(buf *bytes.Buffer, pkg *Package) {
-	buf.WriteString(fmt.Sprintf("service %s {\n", pkg.ServiceName()))
-	for _, rpc := range pkg.RPCs {
+func writeService(buf *bytes.Buffer, svc *Service) {
+	buf.WriteString(fmt.Sprintf("service %s {\n", svc.Name))
+	for _, rpc := range svc.RPCs {
 		writeDocs(buf, rpc.Docs, true)
 		buf.WriteString(fmt.Sprintf(
 			"\trpc %s (%s) returns (%s);\n",

--- a/protobuf/gen_test.go
+++ b/protobuf/gen_test.go
@@ -185,9 +185,10 @@ const expectedService = `service BarService {
 `
 
 func (s *GenSuite) TestWriteService() {
-	writeService(s.buf, &Package{
-		Name: "foo.bar",
-		RPCs: mockRpcs,
+	writeService(s.buf, &Service{
+		Name:   "BarService",
+		Global: true,
+		RPCs:   mockRpcs,
 	})
 	s.Equal(expectedService, s.buf.String())
 }
@@ -210,7 +211,9 @@ func (s *GenSuite) TestGenerate() {
 		Messages: []*Message{mockMsg},
 		Enums:    []*Enum{mockEnum},
 		Options:  Options{"foo": NewLiteralValue("true")},
-		RPCs:     mockRpcs,
+		Services: []*Service{
+			{Name: "BarService", Global: true, RPCs: mockRpcs},
+		},
 	})
 	s.Nil(err)
 

--- a/protobuf/protobuf.go
+++ b/protobuf/protobuf.go
@@ -17,7 +17,7 @@ type Package struct {
 	Options  Options
 	Messages []*Message
 	Enums    []*Enum
-	RPCs     []*RPC
+	Services []*Service
 }
 
 // Import tries to import the given protobuf type to the current package.
@@ -45,9 +45,9 @@ func (p *Package) isImported(file string) bool {
 	return false
 }
 
-// ServiceName returns the service name of the package.
-func (p *Package) ServiceName() string {
-	parts := strings.Split(p.Name, ".")
+// ServiceName returns the service name.
+func ServiceName(name string) string {
+	parts := strings.Split(name, ".")
 	last := parts[len(parts)-1]
 	return strings.ToUpper(string(last[0])) + last[1:] + "Service"
 }
@@ -340,4 +340,14 @@ type RPC struct {
 	Input      Type
 	Output     Type
 	Options    Options
+}
+
+// Service is logical group of multiple RPC methods.
+type Service struct {
+	Docs []string
+	Name string
+	RPCs []*RPC
+	// Global determines if server should be defined as a set of global functions.
+	Global  bool
+	Options Options
 }

--- a/protobuf/transform_test.go
+++ b/protobuf/transform_test.go
@@ -726,7 +726,7 @@ func (s *TransformerSuite) TestTransform() {
 	}, pkg.Imports)
 	s.Equal(1, len(pkg.Enums))
 	s.Equal(5, len(pkg.Messages))
-	s.Equal(0, len(pkg.RPCs))
+	s.Equal(0, len(pkg.Services))
 
 	pkg = s.t.Transform(pkgs[1])
 	s.Equal("gopkg.in.srcd.proteus.v1.fixtures.subpkg", pkg.Name)
@@ -743,13 +743,23 @@ func (s *TransformerSuite) TestTransform() {
 		"Point",
 		"Point_GeneratedMethodOnPointerRequest",
 		"Point_GeneratedMethodRequest",
+		"GenArgsRequest",
+		"GenArgsErrRequest",
+		"GenRetResponse",
+		"GenRetErrResponse",
+		"GenVarRequest",
+		"GenVarResponse",
+		"NameRequest",
+		"NameResponse",
 	}
 	s.Equal(len(msgs), len(pkg.Messages))
 	for _, m := range pkg.Messages {
 		s.True(hasString(m.Name, msgs), fmt.Sprintf("should have message %s", m.Name))
 	}
 
-	s.Equal(4, len(pkg.RPCs))
+	s.Equal(2, len(pkg.Services))
+	s.Equal(4, len(pkg.Services[0].RPCs))
+	s.Equal(6, len(pkg.Services[1].RPCs))
 }
 
 func hasString(str string, coll []string) bool {

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -194,6 +194,9 @@ func getPackagesInfo(pkgs []*scanner.Package) *packagesInfo {
 
 	for _, p := range pkgs {
 		result.packages[p.Path] = struct{}{}
+		for _, imp := range p.Import {
+			result.packages[imp.Path] = struct{}{}
+		}
 		for n, t := range p.Aliases {
 			if _, ok := enums[n]; !ok {
 				result.aliases[n] = t

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -100,7 +100,7 @@ func (s *ResolverSuite) TestIsCustomType() {
 	}
 
 	for _, c := range cases {
-		s.Equal(c.result, s.r.isCustomType(&scanner.Named{nil, c.path, c.name}), "%s.%s", c.path, c.name)
+		s.Equal(c.result, s.r.isCustomType(&scanner.Named{nil, c.path, c.name, false}), "%s.%s", c.path, c.name)
 	}
 }
 
@@ -200,7 +200,7 @@ func (s *ResolverSuite) TestResolve() {
 		},
 		Output: []scanner.Type{
 			scanner.NewBasic("bool"),
-			scanner.NewNamed("", "error"),
+			scanner.NewNamedInterface("", "error"),
 		},
 	}, findFuncByName("Generated", pkgs[1].Funcs))
 

--- a/rpc/context.go
+++ b/rpc/context.go
@@ -9,11 +9,9 @@ import (
 )
 
 type context struct {
-	implName        string
-	constructorName string
-	proto           *protobuf.Package
-	pkg             *types.Package
-	imports         []string
+	proto   *protobuf.Package
+	pkg     *types.Package
+	imports []string
 }
 
 func (c *context) isNameDefined(name string) bool {
@@ -105,11 +103,36 @@ func (c *context) addImport(path string) {
 	c.imports = append(c.imports, path)
 }
 
-func serviceImplName(pkg *protobuf.Package) string {
-	n := pkg.ServiceName()
-	return strings.ToLower(string(n[0])) + n[1:] + "Server"
+func firstUpper(n string) string {
+	return strings.ToUpper(string(n[0])) + n[1:]
 }
 
-func constructorName(pkg *protobuf.Package) string {
-	return fmt.Sprintf("New%sServer", pkg.ServiceName())
+func firstLower(n string) string {
+	return strings.ToLower(string(n[0])) + n[1:]
+}
+
+func serverImplName(n string) string {
+	return firstLower(n) + "Server"
+}
+
+func serverInfName(n string) string {
+	return firstUpper(n) + "Server"
+}
+
+func clientInfName(n string) string {
+	return firstUpper(n) + "Client"
+}
+
+func clientImplName(n string) string {
+	// name xxxClient is already taken by protobuf codegen
+	return firstLower(n) + "Remote"
+}
+
+func serverConstructorName(n string) string {
+	return fmt.Sprintf("New%sServer", firstUpper(n))
+}
+
+func clientConstructorName(n string) string {
+	// name NewXxxClient is already taken by protobuf codegen
+	return fmt.Sprintf("New%sRemote", firstUpper(n))
 }

--- a/rpc/context_test.go
+++ b/rpc/context_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"gopkg.in/src-d/proteus.v1/protobuf"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/src-d/proteus.v1/protobuf"
 
 	"gopkg.in/src-d/go-parse-utils.v1"
 )

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -331,6 +331,7 @@ const expectedGeneratedFile = `package subpkg
 import (
 	xcontext "golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"context"
 )
 
 type subpkgServiceServer struct {
@@ -369,31 +370,31 @@ type svcServer struct {
 func NewSvcServer(s Svc) SvcServer {
 	return &svcServer{Svc: s}
 }
-func (s *svcServer) GenArgs(ctx context.Context, in *GenArgsRequest) (result *Point, err error) {
+func (s *svcServer) GenArgs(ctx xcontext.Context, in *GenArgsRequest) (result *Point, err error) {
 	result = new(Point)
 	result = s.Svc.GenArgs(in.Arg1, in.Arg2)
 	return
 }
-func (s *svcServer) GenArgsErr(ctx context.Context, in *GenArgsErrRequest) (result *Point, err error) {
+func (s *svcServer) GenArgsErr(ctx xcontext.Context, in *GenArgsErrRequest) (result *Point, err error) {
 	result = new(Point)
 	result, err = s.Svc.GenArgsErr(in.Arg1, in.Arg2)
 	return
 }
-func (s *svcServer) GenRet(ctx context.Context, in *Point) (result *GenRetResponse, err error) {
+func (s *svcServer) GenRet(ctx xcontext.Context, in *Point) (result *GenRetResponse, err error) {
 	result = new(GenRetResponse)
 	result.Result1, result.Result2 = s.Svc.GenRet(in)
 	return
 }
-func (s *svcServer) GenRetErr(ctx context.Context, in *Point) (result *GenRetErrResponse, err error) {
+func (s *svcServer) GenRetErr(ctx xcontext.Context, in *Point) (result *GenRetErrResponse, err error) {
 	result = new(GenRetErrResponse)
 	result.Result1, result.Result2, err = s.Svc.GenRetErr(in)
 	return
 }
-func (s *svcServer) GenVar(ctx context.Context, in *GenVarRequest) (result *GenVarResponse, err error) {
+func (s *svcServer) GenVar(ctx xcontext.Context, in *GenVarRequest) (result *GenVarResponse, err error) {
 	err = s.Svc.GenVar(in.Arg1, in.Arg2...)
 	return
 }
-func (s *svcServer) Name(ctx context.Context, in *NameRequest) (result *NameResponse, err error) {
+func (s *svcServer) Name(ctx xcontext.Context, in *NameRequest) (result *NameResponse, err error) {
 	result = new(NameResponse)
 	result.Result1 = s.Svc.Name()
 	return

--- a/scanner/package.go
+++ b/scanner/package.go
@@ -13,6 +13,7 @@ type Package struct {
 	Resolved   bool
 	Path       string
 	Name       string
+	Import     []*Import
 	Structs    []*Struct
 	Enums      []*Enum
 	Funcs      []*Func
@@ -274,6 +275,12 @@ func (d *Docs) SetDocs(comments *ast.CommentGroup) {
 			(&ast.CommentGroup{List: list}).Text(),
 		), "\n")
 	}
+}
+
+// Import is a package import statement.
+type Import struct {
+	Name string
+	Path string
 }
 
 // Enum consists of a list of possible values.

--- a/scanner/package.go
+++ b/scanner/package.go
@@ -10,13 +10,14 @@ import (
 // a reference of all defined structs and type aliases.
 // A Package is only safe to use once it is resolved.
 type Package struct {
-	Resolved bool
-	Path     string
-	Name     string
-	Structs  []*Struct
-	Enums    []*Enum
-	Funcs    []*Func
-	Aliases  map[string]Type
+	Resolved   bool
+	Path       string
+	Name       string
+	Structs    []*Struct
+	Enums      []*Enum
+	Funcs      []*Func
+	Interfaces []*Interface
+	Aliases    map[string]Type
 }
 
 // collectEnums finds the enum values collected during the scan and generates
@@ -137,8 +138,9 @@ func (b Basic) UnqualifiedName() string {
 // Named is non-basic type identified by a name on some package.
 type Named struct {
 	*BaseType
-	Path string
-	Name string
+	Path      string
+	Name      string
+	Interface bool
 }
 
 // String returns a string representation for the type
@@ -165,6 +167,17 @@ func NewNamed(path, name string) Type {
 		newBaseType(),
 		path,
 		name,
+		false,
+	}
+}
+
+// NewNamedInterface creates a new named interface type given its package path and name.
+func NewNamedInterface(path, name string) Type {
+	return &Named{
+		newBaseType(),
+		path,
+		name,
+		true,
 	}
 }
 
@@ -315,4 +328,11 @@ type Func struct {
 	Output   []Type
 	// IsVariadic will be true if the last input parameter is variadic.
 	IsVariadic bool
+}
+
+// Interface represents a Go interface with its name and methods.
+type Interface struct {
+	Docs
+	Name    string
+	Methods []*Func
 }


### PR DESCRIPTION
Generate RPC services from Go interfaces. Also make transform to generate service definition instead of a list of RPCs.