### PR TITLE
Don't panic when scanning map interface types

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -243,6 +243,10 @@ func scanType(typ types.Type) (t Type) {
 	case *types.Map:
 		key := scanType(u.Key())
 		val := scanType(u.Elem())
+		if val == nil {
+			report.Warn("ignoring map with value type %s", typ.String())
+			return nil
+		}
 		t = NewMap(key, val)
 	default:
 		report.Warn("ignoring type %s", typ.String())

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -93,6 +93,11 @@ func TestScanType(t *testing.T) {
 			types.NewInterface(nil, nil),
 			nil,
 		},
+		{
+			"map interface",
+			types.NewMap(types.Typ[types.String], &types.Interface{}),
+			nil,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Fixes a panic when using proteus to scan a struct with a field typed `map[string]interface{}`.