### PR TITLE
add support for `proteus:"(protobuf field id)"` in golang tag

### DIFF
--- a/protobuf/transform.go
+++ b/protobuf/transform.go
@@ -256,6 +256,12 @@ func (t *Transformer) transformField(pkg *Package, msg *Message, field *scanner.
 		Repeated: repeated,
 	}
 
+	// If this field has set pos in tag,
+	// use customize protobuf positin.
+	if field.Pos != 0 {
+		f.Pos = field.Pos
+	}
+
 	// []byte is the only repeated type that maps to
 	// a non-repeated type in protobuf, so we handle
 	// it a bit differently.

--- a/scanner/package.go
+++ b/scanner/package.go
@@ -302,6 +302,7 @@ type Field struct {
 	Docs
 	Name string
 	Type Type
+	Pos  int
 }
 
 // Func is either a function or a method. Receiver will be nil in functions,

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -294,6 +295,7 @@ func scanStruct(s *Struct, elem *types.Struct) *Struct {
 		f := &Field{
 			Name: v.Name(),
 			Type: scanType(v.Type()),
+			Pos:  getProtoID(v, tags),
 		}
 		if f.Type == nil {
 			continue
@@ -388,6 +390,17 @@ func (v enumValues) Less(i, j int) bool {
 
 func isIgnoredField(f *types.Var, tags []string) bool {
 	return !f.Exported() || (len(tags) > 0 && tags[0] == "-")
+}
+
+func getProtoID(f *types.Var, tags []string) int {
+	if len(tags) == 0 {
+		return 0
+	}
+	i, err := strconv.Atoi(tags[0])
+	if err != nil {
+		return 0
+	}
+	return i
 }
 
 func objectsInScope(scope *types.Scope) (objs []types.Object) {


### PR DESCRIPTION
Now you can specify the ID of the peoto file in the following way:
type Example struct {
    Filed int32 `proteus:"101"`
}

This example will generate the following protobuf message.

message Example {
        int32 Filed = 101;
}